### PR TITLE
Suppress warning of keyword arguments introduced in Ruby 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.3
   DisplayCopNames: true
   DisplayStyleGuide: true
 

--- a/lib/elftools/sections/sections.rb
+++ b/lib/elftools/sections/sections.rb
@@ -21,7 +21,7 @@ module ELFTools
       # @param [#pos=, #read] stream Streaming object.
       # @return [ELFTools::Sections::Section]
       #   Return object dependes on +header.sh_type+.
-      def create(header, stream, *args)
+      def create(header, stream, *args, **kwargs)
         klass = case header.sh_type
                 when Constants::SHT_DYNAMIC then DynamicSection
                 when Constants::SHT_NULL then NullSection
@@ -31,7 +31,7 @@ module ELFTools
                 when Constants::SHT_SYMTAB, Constants::SHT_DYNSYM then SymTabSection
                 else Section
                 end
-        klass.new(header, stream, *args)
+        klass.new(header, stream, *args, **kwargs)
       end
     end
   end

--- a/lib/elftools/segments/segments.rb
+++ b/lib/elftools/segments/segments.rb
@@ -19,7 +19,7 @@ module ELFTools
       # @param [#pos=, #read] stream Streaming object.
       # @return [ELFTools::Segments::Segment]
       #   Return object dependes on +header.p_type+.
-      def create(header, stream, *args)
+      def create(header, stream, *args, **kwargs)
         klass = case header.p_type
                 when Constants::PT_DYNAMIC then DynamicSegment
                 when Constants::PT_INTERP then InterpSegment
@@ -27,7 +27,7 @@ module ELFTools
                 when Constants::PT_NOTE then NoteSegment
                 else Segment
                 end
-        klass.new(header, stream, *args)
+        klass.new(header, stream, *args, **kwargs)
       end
     end
   end


### PR DESCRIPTION
[Fix this](https://travis-ci.org/david942j/rbelftools/jobs/590603310)