### PR TITLE
elftools: Add finer-grained exceptions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,10 @@ AllCops:
 Layout/EndOfLine:
   EnforcedStyle: lf
 
+Layout/LineLength:
+  Enabled: true
+  Max: 120
+
 Metrics/AbcSize:
   Enabled: false
 
@@ -21,10 +25,6 @@ Metrics/BlockLength:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-Metrics/LineLength:
-  Enabled: true
-  Max: 120
-
 Naming/ClassAndModuleCamelCase:
   Exclude:
     - lib/elftools/structs.rb
@@ -33,7 +33,7 @@ Naming/ClassAndModuleCamelCase:
 Naming/ConstantName:
   Enabled: false
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 
 Style/FormatStringToken:

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -339,21 +339,21 @@ module ELFTools
     def identify
       stream.pos = 0
       magic = stream.read(4)
-      raise ELFError, "Invalid magic number #{magic.inspect}" unless magic == Constants::ELFMAG
+      raise ELFMagicError, "Invalid magic number #{magic.inspect}" unless magic == Constants::ELFMAG
 
       ei_class = stream.read(1).ord
       @elf_class = {
         1 => 32,
         2 => 64
       }[ei_class]
-      raise ELFError, format('Invalid EI_CLASS "\x%02x"', ei_class) if elf_class.nil?
+      raise ELFClassError, format('Invalid EI_CLASS "\x%02x"', ei_class) if elf_class.nil?
 
       ei_data = stream.read(1).ord
       @endian = {
         1 => :little,
         2 => :big
       }[ei_data]
-      raise ELFError, format('Invalid EI_DATA "\x%02x"', ei_data) if endian.nil?
+      raise ELFDataError, format('Invalid EI_DATA "\x%02x"', ei_data) if endian.nil?
     end
 
     def create_section(n)

--- a/lib/elftools/exceptions.rb
+++ b/lib/elftools/exceptions.rb
@@ -3,4 +3,13 @@
 module ELFTools
   # Being raised when parsing error.
   class ELFError < StandardError; end
+
+  # Raised on invalid ELF magic.
+  class ELFMagicError < ELFError; end
+
+  # Raised on invalid ELF class (EI_CLASS).
+  class ELFClassError < ELFError; end
+
+  # Raised on invalid ELF data encoding (EI_DATA).
+  class ELFDataError < ELFError; end
 end


### PR DESCRIPTION
Refactors ELFError into distinct child errors for specific
failures, allowing consumers of rbelftools to perform
more specific error handling. ELFError remains at the top
of the exception hierarchy for backwards compatibility.