### PR TITLE
Modification of section data, creating new symbols, other improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,3 +41,6 @@ Style/AccessorGrouping:
 
 Style/FormatStringToken:
   Enabled: false
+
+Style/TrivialAccessors:
+  AllowDSLWriters: true

--- a/lib/elftools/constants.rb
+++ b/lib/elftools/constants.rb
@@ -250,7 +250,7 @@ module ELFTools
     end
     include SHN
 
-    # Section header types, records in +sh_type+.
+    # Section flag mask types, records in +sh_flag+.
     module SHF
       SHF_WRITE = (1 << 0) # Writable
       SHF_ALLOC = (1 << 1) # Occupies memory during execution

--- a/lib/elftools/constants.rb
+++ b/lib/elftools/constants.rb
@@ -251,6 +251,27 @@ module ELFTools
     include SHN
 
     # Section header types, records in +sh_type+.
+    module SHF
+      SHF_WRITE = (1 << 0) # Writable
+      SHF_ALLOC = (1 << 1) # Occupies memory during execution
+      SHF_EXECINSTR = (1 << 2) # Executable
+      SHF_MERGE = (1 << 4) # Might be merged
+      SHF_STRINGS = (1 << 5) # Contains nul-terminated strings
+      SHF_INFO_LINK = (1 << 6) # `sh_info' contains SHT index
+      SHF_LINK_ORDER = (1 << 7) # Preserve order after combining
+      SHF_OS_NONCONFORMING = (1 << 8) # Non-standard OS specific handling required
+      SHF_GROUP = (1 << 9) # Section is member of a group.
+      SHF_TLS = (1 << 10) # Section hold thread-local data.
+      SHF_COMPRESSED = (1 << 11) # Section with compressed data.
+      SHF_MASKOS = 0x0ff00000	# OS-specific.
+      SHF_MASKPROC = 0xf0000000	# Processor-specific
+      SHF_GNU_RETAIN = (1 << 21) # Not to be GCed by linker.
+      SHF_ORDERED = (1 << 30) # Special ordering requirement
+      SHF_EXCLUDE = (1 << 31) # Section is excluded unless referenced or allocated (Solaris).
+    end
+    include SHF
+
+    # Section header types, records in +sh_type+.
     module SHT
       SHT_NULL     = 0 # null section
       SHT_PROGBITS = 1 # information defined by program itself

--- a/lib/elftools/constants.rb
+++ b/lib/elftools/constants.rb
@@ -263,8 +263,8 @@ module ELFTools
       SHF_GROUP = (1 << 9) # Section is member of a group.
       SHF_TLS = (1 << 10) # Section hold thread-local data.
       SHF_COMPRESSED = (1 << 11) # Section with compressed data.
-      SHF_MASKOS = 0x0ff00000	# OS-specific.
-      SHF_MASKPROC = 0xf0000000	# Processor-specific
+      SHF_MASKOS = 0x0ff00000 # OS-specific.
+      SHF_MASKPROC = 0xf0000000 # Processor-specific
       SHF_GNU_RETAIN = (1 << 21) # Not to be GCed by linker.
       SHF_ORDERED = (1 << 30) # Special ordering requirement
       SHF_EXCLUDE = (1 << 31) # Section is excluded unless referenced or allocated (Solaris).

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -336,7 +336,6 @@ module ELFTools
       all = header.to_binary_s
 
       sections.each do |s|
-        assert(s.header.elf_class == elf_class)
         s.rebuild
 
         next if s.size <= 0
@@ -354,15 +353,11 @@ module ELFTools
       header.e_shoff = all.size
 
       sections.each do |s|
-        assert s.header.num_bytes == (elf_class == 64 ? 64 : 40)
-        assert s.header.elf_class == elf_class
         sh = s.header.to_binary_s
-        assert sh.size == 64
         all += sh
       end
 
       all[0...header.num_bytes] = header.to_binary_s
-      assert all.size == header.e_shoff + 64 * sections.size
       all
     end
 

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -321,38 +321,26 @@ module ELFTools
       IO.binwrite(filename, all)
     end
 
-    def preload
-      sections.each {|s| s.data }
-    end
-
-    def elf_class=(arch)
-      raise ArgumentError.new('invalid arch, must be 32/64 bit') unless [32, 64].include? arch
-      preload
-      @elf_class = arch
-      header.elf_class = arch
-      [*sections, *segments].each do |s|
-        puts s.header.class.name
-        s.header.send(:instantiate_all_objs)
-        s.header.elf_class = arch
-      end
-    end
-
     def rebuild
       all = header.to_binary_s
+
       sections.each do |s|
         assert(s.header.elf_class == elf_class)
+        s.header.sh_size = s.size
+
         next if s.size <= 0
         if s.header.sh_addralign != 0
           # align with 0 bytes
           all += "\0" * (-all.size % s.header.sh_addralign)
         end
-        s.header.sh_size = s.size
+
         s.header.sh_offset = all.size
         all += s.data
       end
 
       header.e_shnum = sections.size
       header.e_shoff = all.size
+
       sections.each do |s|
         assert s.header.num_bytes == (elf_class == 64 ? 64 : 40)
         assert s.header.elf_class == elf_class
@@ -360,6 +348,7 @@ module ELFTools
         assert sh.size == 64
         all += sh
       end
+
       all[0...header.num_bytes] = header.to_binary_s
       assert all.size == header.e_shoff + 64 * sections.size
       all

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -175,6 +175,16 @@ module ELFTools
       section_at(header.e_shstrndx)
     end
 
+    alias_method :shstrtab, :strtab_section
+
+    def strtab
+      @strtab ||= section_by_name('.strtab')
+    end
+
+    def symtab
+      @symtab ||= section_by_name('.symtab')
+    end
+
     #========= method about segments
 
     # Number of segments in this file.
@@ -399,7 +409,8 @@ module ELFTools
       Sections::Section.create(shdr, stream,
                                offset_from_vma: method(:offset_from_vma),
                                strtab: method(:strtab_section),
-                               section_at: method(:section_at))
+                               section_at: method(:section_at),
+                               elf: self)
     end
 
     def create_segment(n)

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -330,6 +330,7 @@ module ELFTools
         s.rebuild
 
         next if s.size <= 0
+
         if s.header.sh_addralign != 0
           # align with 0 bytes
           all += "\0" * (-all.size % s.header.sh_addralign)

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -143,7 +143,7 @@ module ELFTools
     #   If +n+ is out of bound, +nil+ is returned.
     def section_at(n)
       @sections ||= LazyArray.new(num_sections, &method(:create_section))
-      @sections[n].tap { |sec| sec.index = n if sec }
+      @sections[n]&.tap { |sec| sec.index = n }
     end
 
     # Fetch all sections with specific type.

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -329,7 +329,8 @@ module ELFTools
     # By default does neither modify sections data nor add newly created sections, only patches headers.
     #
     # @param [String] filename
-    # @param [Boolean] rebuild Whether to fully rebuild the ELF file with {ELFFile#rebuild} method. Does not work with segments!
+    # @param [Boolean] rebuild Whether to fully rebuild the ELF file with {ELFFile#rebuild} method.
+    #   Does not work with segments!
     # @return [void]
     def save(filename, rebuild: false)
       return IO.binwrite(filename, self.rebuild) if rebuild

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -143,8 +143,7 @@ module ELFTools
     #   If +n+ is out of bound, +nil+ is returned.
     def section_at(n)
       @sections ||= LazyArray.new(num_sections, &method(:create_section))
-      @sections[n].index = n if @sections[n]
-      @sections[n]
+      @sections[n].tap { |sec| sec.index = n if sec }
     end
 
     # Fetch all sections with specific type.

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -143,6 +143,7 @@ module ELFTools
     #   If +n+ is out of bound, +nil+ is returned.
     def section_at(n)
       @sections ||= LazyArray.new(num_sections, &method(:create_section))
+      @sections[n].index = n if @sections[n]
       @sections[n]
     end
 
@@ -326,7 +327,7 @@ module ELFTools
 
       sections.each do |s|
         assert(s.header.elf_class == elf_class)
-        s.header.sh_size = s.size
+        s.rebuild
 
         next if s.size <= 0
         if s.header.sh_addralign != 0

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -376,7 +376,7 @@ module ELFTools
       # sections headers are at the end of the ELF
       all += sections.map { |s| s.header.to_binary_s }.join
 
-      # replaces updated header
+      # fields of header were changed
       all[0...header.num_bytes] = header.to_binary_s
       all
     end

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -374,10 +374,7 @@ module ELFTools
       header.e_shoff = all.size
 
       # sections headers are at the end of the ELF
-      sections.each do |s|
-        sh = s.header.to_binary_s
-        all += sh
-      end
+      all += sections.map { |s| s.header.to_binary_s }.join
 
       # replaces updated header
       all[0...header.num_bytes] = header.to_binary_s

--- a/lib/elftools/enums.rb
+++ b/lib/elftools/enums.rb
@@ -1,12 +1,12 @@
+# frozen_string_literal: true
+
 # copyright https://stackoverflow.com/questions/75759/how-to-implement-enums-in-ruby
 #
 class Enum
-  private
-
   def self.enum_attr(name, num)
     name = name.to_s
 
-    define_method(name + '?') do
+    define_method("#{name}?") do
       if self.class.exclusive?
         @attrs == num
       else
@@ -14,7 +14,7 @@ class Enum
       end
     end
 
-    define_method(name + '=') do |set|
+    define_method("#{name}=") do |set|
       if set
         @attrs |= num
       else
@@ -22,8 +22,8 @@ class Enum
       end
     end
 
-    self.define_singleton_method(name.upcase.to_sym) do
-      self.new(num)
+    define_singleton_method(name.upcase.to_sym) do
+      new(num)
     end
 
     @values ||= {}
@@ -34,13 +34,12 @@ class Enum
     @exclusive = enabled
   end
 
-  public
   def self.exclusive?
     @exclusive
   end
 
-  def self.values
-    @values
+  class << self
+    attr_reader :values
   end
 
   def initialize(attrs = 0)

--- a/lib/elftools/enums.rb
+++ b/lib/elftools/enums.rb
@@ -44,7 +44,8 @@ class Enum
   end
 
   def initialize(attrs = 0)
-    @attrs = attrs
+    @attrs = self.class.values.key(attrs) || attrs
+    throw ArgumentError.new("Uknown enum #{attrs}") unless @attrs
   end
 
   def to_i
@@ -57,6 +58,10 @@ class Enum
 
   def inspect
     v = self.class.values[@attrs]
-    v ? "#{self.class.name}::#{v}" : @attrs
+    v ? "#{self.class.name}.#{v.upcase}" : @attrs
+  end
+
+  def ==(other)
+    to_i == other.to_i
   end
 end

--- a/lib/elftools/enums.rb
+++ b/lib/elftools/enums.rb
@@ -44,7 +44,12 @@ class Enum
   end
 
   def initialize(attrs = 0)
-    @attrs = self.class.values.key(attrs) || attrs
+    @attrs =
+      if self.class.values.keys.include?(attrs)
+        attrs
+      else
+        self.class.values.index(attrs.to_s.downcase)
+      end
     throw ArgumentError.new("Uknown enum #{attrs}") unless @attrs
   end
 

--- a/lib/elftools/enums.rb
+++ b/lib/elftools/enums.rb
@@ -47,7 +47,7 @@ class Enum
       if self.class.values.keys.include?(attrs)
         attrs
       else
-        self.class.values.index(attrs.to_s.downcase)
+        self.class.values.key(attrs.to_s.downcase)
       end
     throw ArgumentError.new("Uknown enum #{attrs}") unless @attrs
   end

--- a/lib/elftools/enums.rb
+++ b/lib/elftools/enums.rb
@@ -1,0 +1,62 @@
+# copyright https://stackoverflow.com/questions/75759/how-to-implement-enums-in-ruby
+#
+class Enum
+  private
+
+  def self.enum_attr(name, num)
+    name = name.to_s
+
+    define_method(name + '?') do
+      if self.class.exclusive?
+        @attrs == num
+      else
+        @attrs & num != 0
+      end
+    end
+
+    define_method(name + '=') do |set|
+      if set
+        @attrs |= num
+      else
+        @attrs &= ~num
+      end
+    end
+
+    self.define_singleton_method(name.upcase.to_sym) do
+      self.new(num)
+    end
+
+    @values ||= {}
+    @values[num] = name
+  end
+
+  def self.exclusive(enabled)
+    @exclusive = enabled
+  end
+
+  public
+  def self.exclusive?
+    @exclusive
+  end
+
+  def self.values
+    @values
+  end
+
+  def initialize(attrs = 0)
+    @attrs = attrs
+  end
+
+  def to_i
+    @attrs
+  end
+
+  def to_s
+    self.class.values[@attrs] || @attrs.to_s
+  end
+
+  def inspect
+    v = self.class.values[@attrs]
+    v ? "#{self.class.name}::#{v}" : @attrs
+  end
+end

--- a/lib/elftools/lazy_array.rb
+++ b/lib/elftools/lazy_array.rb
@@ -43,5 +43,9 @@ module ELFTools
 
       @internal[i] ||= @block.call(i)
     end
+
+    def push(*args)
+      @internal.push(*args)
+    end
   end
 end

--- a/lib/elftools/lazy_array.rb
+++ b/lib/elftools/lazy_array.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'delegate'
 
 module ELFTools
@@ -27,7 +28,7 @@ module ELFTools
     #   p arr[3]
     #   # 9
     def initialize(size, &block)
-      __setobj__(Array.new(size))
+      super(Array.new(size))
       @block = block
     end
 

--- a/lib/elftools/lazy_array.rb
+++ b/lib/elftools/lazy_array.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
+require 'delegate'
 
 module ELFTools
   # A helper class for {ELFTools} easy to implement
   # 'lazy loading' objects.
   # Mainly used when loading sections, segments, and
   # symbols.
-  class LazyArray
+  class LazyArray < SimpleDelegator
     # Instantiate a {LazyArray} object.
     # @param [Integer] size
     #   The size of array.
@@ -26,7 +27,7 @@ module ELFTools
     #   p arr[3]
     #   # 9
     def initialize(size, &block)
-      @internal = Array.new(size)
+      __setobj__(Array.new(size))
       @block = block
     end
 
@@ -39,13 +40,9 @@ module ELFTools
     #   return type of block given in {#initialize}.
     def [](i)
       # XXX: support negative index?
-      return nil unless i.between?(0, @internal.size - 1)
+      return nil unless i.between?(0, __getobj__.size - 1)
 
-      @internal[i] ||= @block.call(i)
-    end
-
-    def push(*args)
-      @internal.push(*args)
+      __getobj__[i] ||= @block.call(i)
     end
   end
 end

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -35,8 +35,7 @@ module ELFTools
       #   If +n+ is out of bound, +nil+ is returned.
       def relocation_at(n)
         @relocations ||= LazyArray.new(num_relocations, &method(:create_relocation))
-        @relocations[n].index = n if @relocations[n]
-        @relocations[n]
+        @relocations[n].tap { |rel| rel.index = n if rel }
       end
 
       # Iterate all relocations.

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -19,6 +19,7 @@ module ELFTools
       # Number of relocations in this section.
       # @return [Integer] The number.
       def num_relocations
+        return 0 if header.sh_entsize.zero?
         header.sh_size / header.sh_entsize
       end
 
@@ -57,6 +58,15 @@ module ELFTools
       #   Whole relocations.
       def relocations
         each_relocations.to_a
+      end
+
+      def rebuild
+        @data = ''
+        each_relocations do |r|
+          @data += r.header.to_binary_s
+        end
+
+        super
       end
 
       private
@@ -171,15 +181,6 @@ module ELFTools
 
     def mask_bit(bits = self.header.elf_class)
       bits == 32 ? 8 : 32
-    end
-
-    def rebuild
-      @data = ''
-      each_relocations do |r|
-        @data += r.header.to_binary_s
-      end
-
-      super
     end
   end
 end

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -78,7 +78,7 @@ module ELFTools
         rel = klass.new(endian: header.class.self_endian, offset: stream.pos)
         rel.elf_class = header.elf_class
         rel.read(stream)
-        Relocation.new(rel, stream)
+        Relocation.new(rel, stream, self)
       end
     end
   end
@@ -144,9 +144,14 @@ module ELFTools
     }.freeze
 
     # Instantiate a {Relocation} object.
-    def initialize(header, stream)
+    def initialize(header, stream, section = nil)
       @header = header
       @stream = stream
+      @section = section && -> { section }
+    end
+
+    def section
+      @section && @section.call
     end
 
     # +r_info+ contains sym and type, use two methods

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -79,7 +79,8 @@ module ELFTools
       # @param [Relocation32, Relocation64] type Relocation type, stored in header's r_info low bits.
       # @param [Integer] index Relocation symbol index, stored in header's r_info high bits.
       # @param [Integer] offset Relocation offset, stored in header's r_offset.
-      # @param [Integer, nil] addend Relocation addend, required iff section is a RELA section. Stored in header's r_addend.
+      # @param [Integer, nil] addend Relocation addend, required iff section is a RELA section.
+      #   Stored in header's r_addend.
       # @return [Relocation]
       def append(type:, index:, offset:, addend: nil)
         raise ArgumentError, "#{addend.nil? ? '' : 'un'}expected addend" if addend.nil? == rela?

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -20,6 +20,7 @@ module ELFTools
       # @return [Integer] The number.
       def num_relocations
         return 0 if header.sh_entsize.zero?
+
         header.sh_size / header.sh_entsize
       end
 
@@ -93,48 +94,48 @@ module ELFTools
 
     class Relocation32 < Enum
       exclusive true
-      enum_attr :"none", 0
+      enum_attr :none, 0
       enum_attr :"32", 1
-      enum_attr :"pc32", 2
-      enum_attr :"got32", 3
-      enum_attr :"plt32", 4
-      enum_attr :"copy", 5
-      enum_attr :"glob_dat", 6
-      enum_attr :"jmp_slot", 7
-      enum_attr :"relative", 8
-      enum_attr :"gotoff", 9
-      enum_attr :"gotpc", 10
+      enum_attr :pc32, 2
+      enum_attr :got32, 3
+      enum_attr :plt32, 4
+      enum_attr :copy, 5
+      enum_attr :glob_dat, 6
+      enum_attr :jmp_slot, 7
+      enum_attr :relative, 8
+      enum_attr :gotoff, 9
+      enum_attr :gotpc, 10
       enum_attr :"32plt", 11
       enum_attr :"16", 20
-      enum_attr :"pc16", 21
+      enum_attr :pc16, 21
       enum_attr :"8", 22
-      enum_attr :"pc8", 23
-      enum_attr :"size32", 38
+      enum_attr :pc8, 23
+      enum_attr :size32, 38
     end
 
     class Relocation64 < Enum
       exclusive true
-      enum_attr :"none", 0
+      enum_attr :none, 0
       enum_attr :"64", 1
-      enum_attr :"pc32", 2
-      enum_attr :"got32", 3
-      enum_attr :"plt32", 4
-      enum_attr :"copy", 5
-      enum_attr :"glob_dat", 6
-      enum_attr :"jump_slot", 7
-      enum_attr :"relative", 8
-      enum_attr :"gotpcrel", 9
+      enum_attr :pc32, 2
+      enum_attr :got32, 3
+      enum_attr :plt32, 4
+      enum_attr :copy, 5
+      enum_attr :glob_dat, 6
+      enum_attr :jump_slot, 7
+      enum_attr :relative, 8
+      enum_attr :gotpcrel, 9
       enum_attr :"32", 10
       enum_attr :"32s", 11
       enum_attr :"16", 12
-      enum_attr :"pc16", 13
+      enum_attr :pc16, 13
       enum_attr :"8", 14
-      enum_attr :"pc8", 15
-      enum_attr :"pc64", 24
-      enum_attr :"gotoff64", 25
-      enum_attr :"gotpc32", 26
-      enum_attr :"size32", 32
-      enum_attr :"size64", 33
+      enum_attr :pc8, 15
+      enum_attr :pc64, 24
+      enum_attr :gotoff64, 25
+      enum_attr :gotpc32, 26
+      enum_attr :size32, 32
+      enum_attr :size64, 33
     end
 
     RELOCATION_ARCH = {
@@ -164,12 +165,12 @@ module ELFTools
     end
     alias type r_info_type
 
-    def type_enum(bits = self.header.elf_class)
-      RELOCATION_ARCH[bits].new(self.type)
+    def type_enum(bits = header.elf_class)
+      RELOCATION_ARCH[bits].new(type)
     end
 
     def type=(type)
-      type = RELOCATION_ARCH[self.header.elf_class].new(type) if type.is_a? String
+      type = RELOCATION_ARCH[header.elf_class].new(type) if type.is_a? String
       mask = (1 << mask_bit) - 1
       header.r_info = (header.r_info & (~mask)) | (type.to_i & mask)
     end
@@ -179,7 +180,7 @@ module ELFTools
       header.r_info = (ind << mask_bit) | (header.r_info & mask)
     end
 
-    def mask_bit(bits = self.header.elf_class)
+    def mask_bit(bits = header.elf_class)
       bits == 32 ? 8 : 32
     end
   end

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -11,6 +11,7 @@ module ELFTools
     # Note section records notes
     class RelocationSection < Section
       attr_writer :relocations
+
       # Is this relocation a RELA or REL type.
       # @return [Boolean] If is RELA.
       def rela?
@@ -71,8 +72,8 @@ module ELFTools
         super
       end
 
-      def append(type:, index:, offset:, addend:nil)
-        raise ArgumentError.new("#{addend.nil? ? '' : 'un'}expected addend") if addend.nil? == rela?
+      def append(type:, index:, offset:, addend: nil)
+        raise ArgumentError, "#{addend.nil? ? '' : 'un'}expected addend" if addend.nil? == rela?
 
         klass = rela? ? Structs::ELF_Rela : Structs::ELF_Rel
         hdr = klass.new(endian: header.class.self_endian)

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -35,7 +35,7 @@ module ELFTools
       #   If +n+ is out of bound, +nil+ is returned.
       def relocation_at(n)
         @relocations ||= LazyArray.new(num_relocations, &method(:create_relocation))
-        @relocations[n].tap { |rel| rel.index = n if rel }
+        @relocations[n]&.tap { |rel| rel.index = n }
       end
 
       # Iterate all relocations.

--- a/lib/elftools/sections/section.rb
+++ b/lib/elftools/sections/section.rb
@@ -62,11 +62,11 @@ module ELFTools
       end
 
       def size=(size)
-        throw ArgumentError.new('new size is negative') if size < 0
+        throw ArgumentError.new('new size is negative') if size.negative?
         size -= data.size
-        if size > 0
+        if size.positive?
           @data += '\0' * size
-        elsif size < 0
+        elsif size.negative?
           @data = @data[0...size]
         end
         @data.size

--- a/lib/elftools/sections/section.rb
+++ b/lib/elftools/sections/section.rb
@@ -18,7 +18,7 @@ module ELFTools
       #   The streaming object for further dump.
       # @param [ELFTools::ELFFile] elf
       #   ELFFile that contains section
-      def initialize(header, stream, offset_from_vma: nil, elf: nil, **_kwargs)
+      def initialize(header, stream, elf: nil, **_kwargs)
         @header = header
         @elf = elf
         @stream = stream

--- a/lib/elftools/sections/section.rb
+++ b/lib/elftools/sections/section.rb
@@ -7,7 +7,7 @@ module ELFTools
     class Section
       attr_reader :header # @return [ELFTools::Structs::ELF_Shdr] Section header.
       attr_reader :stream # @return [#pos=, #read] Streaming object.
-      attr_accessor :data
+      attr_writer :data
       attr_accessor :index
 
       # Instantiate a {Section} object.
@@ -26,6 +26,7 @@ module ELFTools
         @stream = stream
         @strtab = strtab
         @offset_from_vma = offset_from_vma
+        @data = nil
       end
 
       # Return +header.sh_type+ in a simplier way.

--- a/lib/elftools/sections/section.rb
+++ b/lib/elftools/sections/section.rb
@@ -21,10 +21,11 @@ module ELFTools
       #   time access +#name+.
       # @param [Method] offset_from_vma
       #   The method to get offset of file, given virtual memory address.
-      def initialize(header, stream, offset_from_vma: nil, strtab: nil, **_kwargs)
+      def initialize(header, stream, offset_from_vma: nil, strtab: nil, elf: nil, **_kwargs)
         @header = header
+        @elf = elf && -> { elf }
         @stream = stream
-        @strtab = strtab
+        @strtab = strtab || elf&.strtab
         @offset_from_vma = offset_from_vma
         @data = nil
       end
@@ -76,6 +77,10 @@ module ELFTools
       def rebuild
         header.sh_size = data.size
         @data
+      end
+
+      def elf
+        @elf && @elf.call
       end
     end
   end

--- a/lib/elftools/sections/section.rb
+++ b/lib/elftools/sections/section.rb
@@ -54,10 +54,15 @@ module ELFTools
         false
       end
 
+      # Return the size of section data with considering modifications.
+      # @return [Integer] Section size.
       def size
-        data.size
+        @data ? @data.size : header.sh_size
       end
 
+      # Updates section size, loading data if necessary and trimming it or extending with null bytes.
+      # @param [Integer] size New section size.
+      # @return [Integer] New section size.
       def size=(size)
         throw ArgumentError.new('new size is negative') if size.negative?
         size -= data.size
@@ -69,6 +74,8 @@ module ELFTools
         @data.size
       end
 
+      # Rebuilds section data, loading it if necessary. Updates headers to match the data.
+      # @return [String] Binary representation of section data
       def rebuild
         header.sh_size = data.size
         @data

--- a/lib/elftools/sections/section.rb
+++ b/lib/elftools/sections/section.rb
@@ -8,6 +8,7 @@ module ELFTools
       attr_reader :header # @return [ELFTools::Structs::ELF_Shdr] Section header.
       attr_reader :stream # @return [#pos=, #read] Streaming object.
       attr_accessor :data
+      attr_accessor :index
 
       # Instantiate a {Section} object.
       # @param [ELFTools::Structs::ELF_Shdr] header
@@ -69,6 +70,11 @@ module ELFTools
           @data = @data[0...size]
         end
         @data.size
+      end
+
+      def rebuild
+        header.sh_size = data.size
+        @data
       end
     end
   end

--- a/lib/elftools/sections/str_tab_section.rb
+++ b/lib/elftools/sections/str_tab_section.rb
@@ -19,6 +19,10 @@ module ELFTools
         Util.cstring(stream, header.sh_offset + offset)
       end
 
+      # Return offset of string in section, appending to section data if necessary.
+      # @param [String] name
+      #   Used for appending new symbols or sections with custom names to {ELFTools::ELFFile}.
+      # @return [Integer] The offset in section at which the name was found or appended.
       def find_or_insert(name)
         return 0 if name.empty?
 

--- a/lib/elftools/sections/str_tab_section.rb
+++ b/lib/elftools/sections/str_tab_section.rb
@@ -14,6 +14,7 @@ module ELFTools
       #   Usually from +shdr.sh_name+ or +sym.st_name+.
       # @return [String] The name without null bytes.
       def name_at(offset)
+        return @data[offset...@data.index("\0", offset)] if @data
         Util.cstring(stream, header.sh_offset + offset)
       end
 

--- a/lib/elftools/sections/str_tab_section.rb
+++ b/lib/elftools/sections/str_tab_section.rb
@@ -16,6 +16,16 @@ module ELFTools
       def name_at(offset)
         Util.cstring(stream, header.sh_offset + offset)
       end
+
+      def find_or_insert(name)
+        return 0 if name.empty?
+        ind = self.data.index("#{name}\0")
+        if ind.nil?
+          ind = self.data.size
+          self.data += "#{name}\0"
+        end
+        ind
+      end
     end
   end
 end

--- a/lib/elftools/sections/str_tab_section.rb
+++ b/lib/elftools/sections/str_tab_section.rb
@@ -15,14 +15,16 @@ module ELFTools
       # @return [String] The name without null bytes.
       def name_at(offset)
         return @data[offset...@data.index("\0", offset)] if @data
+
         Util.cstring(stream, header.sh_offset + offset)
       end
 
       def find_or_insert(name)
         return 0 if name.empty?
-        ind = self.data.index("#{name}\0")
+
+        ind = data.index("#{name}\0")
         if ind.nil?
-          ind = self.data.size
+          ind = data.size
           self.data += "#{name}\0"
         end
         ind

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -175,6 +175,7 @@ module ELFTools
       #   If +Proc+ is given, it will be called at the first time
       #   access {Symbol#name}.
       def initialize(header, stream, section)
+        raise ArgumentError.new("Invalid section") unless section.is_a? Section
         @header = header
         @stream = stream
         @section = -> { section }

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -165,6 +165,7 @@ module ELFTools
         enum_attr :singleton, 5
         enum_attr :eliminate, 6
       end
+
       # Instantiate a {ELFTools::Sections::Symbol} object.
       # @param [ELFTools::Structs::ELF32_sym, ELFTools::Structs::ELF64_sym] header
       #   The symbol header.
@@ -176,7 +177,7 @@ module ELFTools
       def initialize(header, stream, section)
         @header = header
         @stream = stream
-        @section = -> () { section }
+        @section = -> { section }
       end
 
       def section
@@ -190,7 +191,7 @@ module ELFTools
       end
 
       def data
-        @data ||= section.section_at(header.st_shndx).data[header.st_value,header.st_size]
+        @data ||= section.section_at(header.st_shndx).data[header.st_value, header.st_size]
       end
 
       def st_bind

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -9,18 +9,6 @@ module ELFTools
     # Usually for section .symtab and .dynsym,
     # which will refer to symbols in ELF file.
     class SymTabSection < Section
-      # Instantiate a {SymTabSection} object.
-      # There's a +section_at+ lambda for {SymTabSection}
-      # to easily fetch other sections.
-      # @param [ELFTools::Structs::ELF_Shdr] header
-      #   See {Section#initialize} for more information.
-      # @param [#pos=, #read] stream
-      #   See {Section#initialize} for more information.
-      def initialize(header, stream, **_kwargs)
-        # For faster #symbol_by_name
-        super
-      end
-
       # Number of symbols.
       # @return [Integer] The number.
       # @example
@@ -95,7 +83,7 @@ module ELFTools
         super
       end
 
-      def append(name: "", type:, vis: Symbol::Visibility.DEFAULT, bind: Symbol::Bind.LOCAL)
+      def append(type:, name: '', vis: Symbol::Visibility.DEFAULT, bind: Symbol::Bind.LOCAL)
         hdr = Structs::ELF_sym[elf_class].new(endian: header.class.self_endian)
         hdr.elf_class = elf_class
         hdr.st_name = elf.strtab.find_or_insert(name)

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -27,7 +27,7 @@ module ELFTools
       #   If +n+ is out of bound, +nil+ is returned.
       def symbol_at(n)
         @symbols ||= LazyArray.new(num_symbols, &method(:create_symbol))
-        @symbols[n].tap { |sym| sym.index = n if sym }
+        @symbols[n]&.tap { |sym| sym.index = n }
       end
 
       # Iterate all symbols.

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -98,6 +98,8 @@ module ELFTools
           @data += s.header.to_binary_s
         end
 
+        header.sh_info = symbols.index { |s| s.st_bind == Symbol::Bind.GLOBAL } || num_symbols
+
         super
       end
 

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -140,6 +140,17 @@ module ELFTools
         enum_attr :loproc, 13
         enum_attr :hiproc, 15
       end
+
+      class Visibility < Enum
+        exclusive true
+        enum_attr :default, 0
+        enum_attr :internal, 1
+        enum_attr :hidden, 2
+        enum_attr :protected, 3
+        enum_attr :exported, 4
+        enum_attr :singleton, 5
+        enum_attr :eliminate, 6
+      end
       # Instantiate a {ELFTools::Sections::Symbol} object.
       # @param [ELFTools::Structs::ELF32_sym, ELFTools::Structs::ELF64_sym] header
       #   The symbol header.
@@ -182,6 +193,14 @@ module ELFTools
 
       def st_type=(type)
         header.st_info = (header.st_info & (~0xf)) | (type.to_i & 0xf)
+      end
+
+      def st_vis
+        Visibility.new(header.st_other & 0x7)
+      end
+
+      def st_vis=(vis)
+        header.st_other = type.to_i & 0x7
       end
     end
   end

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -27,8 +27,7 @@ module ELFTools
       #   If +n+ is out of bound, +nil+ is returned.
       def symbol_at(n)
         @symbols ||= LazyArray.new(num_symbols, &method(:create_symbol))
-        @symbols[n].index = n if @symbols[n]
-        @symbols[n]
+        @symbols[n].tap { |sym| sym.index = n if sym }
       end
 
       # Iterate all symbols.

--- a/lib/elftools/structs.rb
+++ b/lib/elftools/structs.rb
@@ -12,7 +12,7 @@ module ELFTools
     class ELFStruct < BinData::Record
       # DRY. Many fields have different type in different arch.
       CHOICE_SIZE_T = {
-        selection: :elf_class, choices: { 32 => :uint32, 64 => :uint64 }
+        selection: :elf_class, choices: { 32 => :uint32, 64 => :uint64 }, copy_on_change: true
       }.freeze
 
       attr_accessor :elf_class # @return [Integer] 32 or 64.
@@ -22,6 +22,10 @@ module ELFTools
       # @return [Hash{Integer => Integer}] Patches.
       def patches
         @patches ||= {}
+      end
+
+      def to_h
+        self.field_names.map { |f| [f, self.send(f)] }.to_h
       end
 
       class << self

--- a/lib/elftools/structs.rb
+++ b/lib/elftools/structs.rb
@@ -44,13 +44,12 @@ module ELFTools
               old_method = obj.singleton_method(m)
               obj.singleton_class.send(:undef_method, m)
               obj.define_singleton_method(m) do |val|
-                org = obj.send(f)
-                obj.patches[org.abs_offset] = org.to_binary_s
+                old_method.call(val)
+                updated = obj.send(f)
+                obj.patches[updated.abs_offset] = updated.to_binary_s
               rescue StandardError => e
                 puts "Error at capturing patch changes: #{$ERROR_INFO}"
                 puts "Backtrace:\n\t#{e.backtrace.join("\n\t")}"
-              ensure
-                old_method.call(val)
               end
             end
           end

--- a/lib/elftools/structs.rb
+++ b/lib/elftools/structs.rb
@@ -44,9 +44,15 @@ module ELFTools
               old_method = obj.singleton_method(m)
               obj.singleton_class.send(:undef_method, m)
               obj.define_singleton_method(m) do |val|
-                org = obj.send(f)
-                obj.patches[org.abs_offset] = ELFStruct.pack(val, org.num_bytes)
-                old_method.call(val)
+                begin
+                  org = obj.send(f)
+                  obj.patches[org.abs_offset] = org.to_binary_s
+                rescue StandardError => er
+                  puts "Error at capturing patch changes: #{$!}"
+                  puts "Backtrace:\n\t#{e.backtrace.join("\n\t")}"
+                ensure
+                  old_method.call(val)
+                end
               end
             end
           end

--- a/lib/elftools/structs.rb
+++ b/lib/elftools/structs.rb
@@ -11,9 +11,9 @@ module ELFTools
     # The base structure to define common methods.
     class ELFStruct < BinData::Record
       # DRY. Many fields have different type in different arch.
-      CHOICE_SIZE_T = {
-        selection: :elf_class, choices: { 32 => :uint32, 64 => :uint64 }, copy_on_change: true
-      }.freeze
+      CHOICE_SIZE_T = Proc.new { |t = "uint"|
+        { selection: :elf_class, choices: { 32 => :"#{t}32", 64 => :"#{t}64" }, copy_on_change: true }
+      }
 
       attr_accessor :elf_class # @return [Integer] 32 or 64.
       attr_accessor :offset # @return [Integer] The file offset of this header.
@@ -99,9 +99,9 @@ module ELFTools
       uint16 :e_machine
       uint32 :e_version
       # entry point
-      choice :e_entry, **CHOICE_SIZE_T
-      choice :e_phoff, **CHOICE_SIZE_T
-      choice :e_shoff, **CHOICE_SIZE_T
+      choice :e_entry, **CHOICE_SIZE_T["uint"]
+      choice :e_phoff, **CHOICE_SIZE_T["uint"]
+      choice :e_shoff, **CHOICE_SIZE_T["uint"]
       uint32 :e_flags
       uint16 :e_ehsize # size of this header
       uint16 :e_phentsize # size of each segment
@@ -116,14 +116,14 @@ module ELFTools
       endian :big_and_little
       uint32 :sh_name
       uint32 :sh_type
-      choice :sh_flags, **CHOICE_SIZE_T
-      choice :sh_addr, **CHOICE_SIZE_T
-      choice :sh_offset, **CHOICE_SIZE_T
-      choice :sh_size, **CHOICE_SIZE_T
+      choice :sh_flags, **CHOICE_SIZE_T["uint"]
+      choice :sh_addr, **CHOICE_SIZE_T["uint"]
+      choice :sh_offset, **CHOICE_SIZE_T["uint"]
+      choice :sh_size, **CHOICE_SIZE_T["uint"]
       uint32 :sh_link
       uint32 :sh_info
-      choice :sh_addralign, **CHOICE_SIZE_T
-      choice :sh_entsize, **CHOICE_SIZE_T
+      choice :sh_addralign, **CHOICE_SIZE_T["uint"]
+      choice :sh_entsize, **CHOICE_SIZE_T["uint"]
     end
 
     # Program header structure for 32-bit.
@@ -197,25 +197,25 @@ module ELFTools
     # Dynamic tag header.
     class ELF_Dyn < ELFStruct
       endian :big_and_little
-      choice :d_tag, selection: :elf_class, choices: { 32 => :int32, 64 => :int64 }
+      choice :d_tag, **CHOICE_SIZE_T["int"]
       # This is an union type named +d_un+ in original source,
       # simplify it to be +d_val+ here.
-      choice :d_val, **CHOICE_SIZE_T
+      choice :d_val, **CHOICE_SIZE_T["uint"]
     end
 
     # Rel header in .rel section.
     class ELF_Rel < ELFStruct
       endian :big_and_little
-      choice :r_offset, **CHOICE_SIZE_T
-      choice :r_info, **CHOICE_SIZE_T
+      choice :r_offset, **CHOICE_SIZE_T["uint"]
+      choice :r_info, **CHOICE_SIZE_T["uint"]
     end
 
     # Rela header in .rela section.
     class ELF_Rela < ELFStruct
       endian :big_and_little
-      choice :r_offset, **CHOICE_SIZE_T
-      choice :r_info, **CHOICE_SIZE_T
-      choice :r_addend, selection: :elf_class, choices: { 32 => :int32, 64 => :int64 }
+      choice :r_offset, **CHOICE_SIZE_T["uint"]
+      choice :r_info, **CHOICE_SIZE_T["uint"]
+      choice :r_addend, **CHOICE_SIZE_T["int"]
     end
   end
 end

--- a/lib/elftools/structs.rb
+++ b/lib/elftools/structs.rb
@@ -11,9 +11,9 @@ module ELFTools
     # The base structure to define common methods.
     class ELFStruct < BinData::Record
       # DRY. Many fields have different type in different arch.
-      CHOICE_SIZE_T = Proc.new { |t = "uint"|
+      CHOICE_SIZE_T = proc do |t = 'uint'|
         { selection: :elf_class, choices: { 32 => :"#{t}32", 64 => :"#{t}64" }, copy_on_change: true }
-      }
+      end
 
       attr_accessor :elf_class # @return [Integer] 32 or 64.
       attr_accessor :offset # @return [Integer] The file offset of this header.
@@ -25,7 +25,7 @@ module ELFTools
       end
 
       def to_h
-        self.field_names.map { |f| [f, self.send(f)] }.to_h
+        field_names.map { |f| [f, send(f)] }.to_h
       end
 
       class << self
@@ -44,15 +44,13 @@ module ELFTools
               old_method = obj.singleton_method(m)
               obj.singleton_class.send(:undef_method, m)
               obj.define_singleton_method(m) do |val|
-                begin
-                  org = obj.send(f)
-                  obj.patches[org.abs_offset] = org.to_binary_s
-                rescue StandardError => er
-                  puts "Error at capturing patch changes: #{$!}"
-                  puts "Backtrace:\n\t#{e.backtrace.join("\n\t")}"
-                ensure
-                  old_method.call(val)
-                end
+                org = obj.send(f)
+                obj.patches[org.abs_offset] = org.to_binary_s
+              rescue StandardError => e
+                puts "Error at capturing patch changes: #{$ERROR_INFO}"
+                puts "Backtrace:\n\t#{e.backtrace.join("\n\t")}"
+              ensure
+                old_method.call(val)
               end
             end
           end
@@ -99,9 +97,9 @@ module ELFTools
       uint16 :e_machine
       uint32 :e_version
       # entry point
-      choice :e_entry, **CHOICE_SIZE_T["uint"]
-      choice :e_phoff, **CHOICE_SIZE_T["uint"]
-      choice :e_shoff, **CHOICE_SIZE_T["uint"]
+      choice :e_entry, **CHOICE_SIZE_T['uint']
+      choice :e_phoff, **CHOICE_SIZE_T['uint']
+      choice :e_shoff, **CHOICE_SIZE_T['uint']
       uint32 :e_flags
       uint16 :e_ehsize # size of this header
       uint16 :e_phentsize # size of each segment
@@ -116,14 +114,14 @@ module ELFTools
       endian :big_and_little
       uint32 :sh_name
       uint32 :sh_type
-      choice :sh_flags, **CHOICE_SIZE_T["uint"]
-      choice :sh_addr, **CHOICE_SIZE_T["uint"]
-      choice :sh_offset, **CHOICE_SIZE_T["uint"]
-      choice :sh_size, **CHOICE_SIZE_T["uint"]
+      choice :sh_flags, **CHOICE_SIZE_T['uint']
+      choice :sh_addr, **CHOICE_SIZE_T['uint']
+      choice :sh_offset, **CHOICE_SIZE_T['uint']
+      choice :sh_size, **CHOICE_SIZE_T['uint']
       uint32 :sh_link
       uint32 :sh_info
-      choice :sh_addralign, **CHOICE_SIZE_T["uint"]
-      choice :sh_entsize, **CHOICE_SIZE_T["uint"]
+      choice :sh_addralign, **CHOICE_SIZE_T['uint']
+      choice :sh_entsize, **CHOICE_SIZE_T['uint']
     end
 
     # Program header structure for 32-bit.
@@ -197,17 +195,17 @@ module ELFTools
     # Dynamic tag header.
     class ELF_Dyn < ELFStruct
       endian :big_and_little
-      choice :d_tag, **CHOICE_SIZE_T["int"]
+      choice :d_tag, **CHOICE_SIZE_T['int']
       # This is an union type named +d_un+ in original source,
       # simplify it to be +d_val+ here.
-      choice :d_val, **CHOICE_SIZE_T["uint"]
+      choice :d_val, **CHOICE_SIZE_T['uint']
     end
 
     # Rel header in .rel section.
     class ELF_Rel < ELFStruct
       endian :big_and_little
-      choice :r_offset, **CHOICE_SIZE_T["uint"]
-      choice :r_info, **CHOICE_SIZE_T["uint"]
+      choice :r_offset, **CHOICE_SIZE_T['uint']
+      choice :r_info, **CHOICE_SIZE_T['uint']
 
       def r_addend
         nil
@@ -217,9 +215,9 @@ module ELFTools
     # Rela header in .rela section.
     class ELF_Rela < ELFStruct
       endian :big_and_little
-      choice :r_offset, **CHOICE_SIZE_T["uint"]
-      choice :r_info, **CHOICE_SIZE_T["uint"]
-      choice :r_addend, **CHOICE_SIZE_T["int"]
+      choice :r_offset, **CHOICE_SIZE_T['uint']
+      choice :r_info, **CHOICE_SIZE_T['uint']
+      choice :r_addend, **CHOICE_SIZE_T['int']
     end
   end
 end

--- a/lib/elftools/structs.rb
+++ b/lib/elftools/structs.rb
@@ -208,6 +208,10 @@ module ELFTools
       endian :big_and_little
       choice :r_offset, **CHOICE_SIZE_T["uint"]
       choice :r_info, **CHOICE_SIZE_T["uint"]
+
+      def r_addend
+        nil
+      end
     end
 
     # Rela header in .rela section.


### PR DESCRIPTION
Hello
I've had a college project where I have benefitted from your library, though I have quickly realised it was not going to be enough.
These changes are just as I have sent the project in yesterday and they still lack a bit of refinement, I am going to refactor it.

I ran the tests and they passed, but the functionality implemented in this PR was only tested on ET_REL linker object files and lacks tests.

Summary:
- allow preloading of data (build all structures in memory)
- allow modification and rebuilding ELF files – adding, deleting, reordering sections, symbols, relocations
- fixed a bug where elf header's `e_ident`'s attributes cannot be written, as they cannot be packed into int by the bindata patches-gathering monkeypatch

Implementation decisions:
- no idea what is LazyArray for, will try to get rid of it in refactor and still achieve lazy loading (even though the whole elf is loaded into memory when saving)
- created new Enums that are a bit better, but also bad. Needs some thinking
- properly splitting the functionality of appending symbols requires classes to have access to relative parent (eg. `Relocation` to a `RelocationSection` and `RelocationSection` to an `ELFFile`), things get complicated because this causes loops that break `loaded_headers`. Worked around it with lambdas containing variables, but might consider appending loaded headers to some elffile internal set structure (thus fixing "bad idea..." loaded headers behavior)

Please do not hesitate to comment in case you spot anything i forgot to mention and that would need fixing in the code.