### PR TITLE
Enums

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,3 +41,6 @@ Style/AccessorGrouping:
 
 Style/FormatStringToken:
   Enabled: false
+
+Style/TrivialAccessors:
+  AllowDSLWriters: true

--- a/lib/elftools/enums.rb
+++ b/lib/elftools/enums.rb
@@ -7,19 +7,7 @@ class Enum
     name = name.to_s
 
     define_method("#{name}?") do
-      if self.class.exclusive?
-        @attrs == num
-      else
-        @attrs & num != 0
-      end
-    end
-
-    define_method("#{name}=") do |set|
-      if set
-        @attrs |= num
-      else
-        @attrs &= ~num
-      end
+      @attrs == num
     end
 
     define_singleton_method(name.upcase.to_sym) do
@@ -32,16 +20,6 @@ class Enum
 
   class << self
     attr_reader :values
-
-    def exclusive?
-      @exclusive
-    end
-
-    private
-
-    def exclusive(enabled)
-      @exclusive = enabled
-    end
   end
 
   # Initialize enum with value or name

--- a/lib/elftools/enums.rb
+++ b/lib/elftools/enums.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# copyright https://stackoverflow.com/questions/75759/how-to-implement-enums-in-ruby
+#
+class Enum
+  def self.enum_attr(name, num)
+    name = name.to_s
+
+    define_method("#{name}?") do
+      if self.class.exclusive?
+        @attrs == num
+      else
+        @attrs & num != 0
+      end
+    end
+
+    define_method("#{name}=") do |set|
+      if set
+        @attrs |= num
+      else
+        @attrs &= ~num
+      end
+    end
+
+    define_singleton_method(name.upcase.to_sym) do
+      new(num)
+    end
+
+    @values ||= {}
+    @values[num] = name
+  end
+
+  def self.exclusive(enabled)
+    @exclusive = enabled
+  end
+
+  def self.exclusive?
+    @exclusive
+  end
+
+  class << self
+    attr_reader :values
+  end
+
+  def initialize(attrs = 0)
+    @attrs =
+      if self.class.values.keys.include?(attrs)
+        attrs
+      else
+        self.class.values.key(attrs.to_s.downcase)
+      end
+    throw ArgumentError.new("Uknown enum #{attrs}") unless @attrs
+  end
+
+  def to_i
+    @attrs
+  end
+
+  def to_s
+    self.class.values[@attrs] || @attrs.to_s
+  end
+
+  def inspect
+    v = self.class.values[@attrs]
+    v ? "#{self.class.name}.#{v.upcase}" : @attrs
+  end
+
+  def ==(other)
+    to_i == other.to_i
+  end
+end

--- a/lib/elftools/enums.rb
+++ b/lib/elftools/enums.rb
@@ -30,26 +30,32 @@ class Enum
     @values[num] = name
   end
 
-  def self.exclusive(enabled)
-    @exclusive = enabled
-  end
-
-  def self.exclusive?
-    @exclusive
-  end
-
   class << self
     attr_reader :values
+
+    def exclusive?
+      @exclusive
+    end
+
+    private
+
+    def exclusive(enabled)
+      @exclusive = enabled
+    end
   end
 
-  def initialize(attrs = 0)
+  # Initialize enum with value or name
+  # @param [Integer, Symbol] n Value or name.
+  # @return [Enum]
+  #   Throws ArgumentError if enum name or value is invalid.
+  def initialize(value = 0)
     @attrs =
-      if self.class.values.keys.include?(attrs)
-        attrs
+      if self.class.values.keys.include?(value)
+        value
       else
-        self.class.values.key(attrs.to_s.downcase)
+        self.class.values.key(value.to_s.downcase)
       end
-    throw ArgumentError.new("Uknown enum #{attrs}") unless @attrs
+    throw ArgumentError.new("Uknown enum #{value}") unless @attrs
   end
 
   def to_i

--- a/lib/elftools/enums.rb
+++ b/lib/elftools/enums.rb
@@ -7,7 +7,7 @@ class Enum
     name = name.to_s
 
     define_method("#{name}?") do
-      @attrs == num
+      @value == num
     end
 
     define_singleton_method(name.upcase.to_sym) do
@@ -27,26 +27,26 @@ class Enum
   # @return [Enum]
   #   Throws ArgumentError if enum name or value is invalid.
   def initialize(value = 0)
-    @attrs =
+    @value =
       if self.class.values.keys.include?(value)
         value
       else
         self.class.values.key(value.to_s.downcase)
       end
-    throw ArgumentError.new("Uknown enum #{value}") unless @attrs
+    raise ArgumentError.new("Unknown enum #{value}") unless @value
   end
 
   def to_i
-    @attrs
+    @value
   end
 
   def to_s
-    self.class.values[@attrs] || @attrs.to_s
+    self.class.values[@value] || @value.to_s
   end
 
   def inspect
-    v = self.class.values[@attrs]
-    v ? "#{self.class.name}.#{v.upcase}" : @attrs
+    v = self.class.values[@value]
+    v ? "#{self.class.name}.#{v.upcase}" : @value
   end
 
   def ==(other)

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -176,6 +176,7 @@ module ELFTools
     end
 
     private
+
     def mask_bit
       header.elf_class == 32 ? 8 : 32
     end

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require 'elftools/constants'
+require 'elftools/enums'
 require 'elftools/sections/section'
 require 'elftools/structs'
-require 'elftools/enums'
 
 module ELFTools
   module Sections
@@ -159,12 +159,13 @@ module ELFTools
     end
 
     # Update relocation type.
-    # @param [String, Relocation64, RElocation32, Integer] type Relocation type
-    def type=(type)
+    # @param [String, Relocation64, Relocation32, Integer] type Relocation type
+    def r_info_type=(type)
       type = RELOCATION_ARCH[header.elf_class].new(type) if type.is_a? String
       mask = (1 << mask_bit) - 1
       header.r_info = (header.r_info & (~mask)) | (type.to_i & mask)
     end
+    alias type= r_info_type=
 
     # Update relocation symbol index.
     # @param [Integer] ind symbol index.

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -80,7 +80,6 @@ module ELFTools
     attr_reader :stream # @return [#pos=, #read] Streaming object.
 
     class Relocation32 < Enum
-      exclusive true
       enum_attr :none, 0
       enum_attr :"32", 1
       enum_attr :pc32, 2
@@ -101,7 +100,6 @@ module ELFTools
     end
 
     class Relocation64 < Enum
-      exclusive true
       enum_attr :none, 0
       enum_attr :"64", 1
       enum_attr :pc32, 2

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'elftools/sections/section'
 require 'elftools/enums'
+require 'elftools/sections/section'
 
 module ELFTools
   module Sections

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -106,7 +106,6 @@ module ELFTools
 
       # based on https://docs.oracle.com/cd/E23824_01/html/819-0690/chapter6-79797.html
       class Bind < Enum
-        exclusive true
         enum_attr :local, 0
         enum_attr :global, 1
         enum_attr :weak, 2
@@ -117,7 +116,6 @@ module ELFTools
       end
 
       class Type < Enum
-        exclusive true
         enum_attr :notype, 0
         enum_attr :object, 1
         enum_attr :func, 2
@@ -133,7 +131,6 @@ module ELFTools
       end
 
       class Visibility < Enum
-        exclusive true
         enum_attr :default, 0
         enum_attr :internal, 1
         enum_attr :hidden, 2

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'elftools/sections/section'
+require 'elftools/enums'
 
 module ELFTools
   module Sections
@@ -103,6 +104,45 @@ module ELFTools
       attr_reader :header # @return [ELFTools::Structs::ELF32_sym, ELFTools::Structs::ELF64_sym] Section header.
       attr_reader :stream # @return [#pos=, #read] Streaming object.
 
+      # based on https://docs.oracle.com/cd/E23824_01/html/819-0690/chapter6-79797.html
+      class Bind < Enum
+        exclusive true
+        enum_attr :local, 0
+        enum_attr :global, 1
+        enum_attr :weak, 2
+        enum_attr :loos, 10
+        enum_attr :hios, 12
+        enum_attr :loproc, 13
+        enum_attr :hiproc, 15
+      end
+
+      class Type < Enum
+        exclusive true
+        enum_attr :notype, 0
+        enum_attr :object, 1
+        enum_attr :func, 2
+        enum_attr :section, 3
+        enum_attr :file, 4
+        enum_attr :common, 5
+        enum_attr :tls, 6
+        enum_attr :loos, 10
+        enum_attr :hios, 12
+        enum_attr :sparc_register, 13
+        enum_attr :loproc, 13
+        enum_attr :hiproc, 15
+      end
+
+      class Visibility < Enum
+        exclusive true
+        enum_attr :default, 0
+        enum_attr :internal, 1
+        enum_attr :hidden, 2
+        enum_attr :protected, 3
+        enum_attr :exported, 4
+        enum_attr :singleton, 5
+        enum_attr :eliminate, 6
+      end
+
       # Instantiate a {ELFTools::Sections::Symbol} object.
       # @param [ELFTools::Structs::ELF32_sym, ELFTools::Structs::ELF64_sym] header
       #   The symbol header.
@@ -121,6 +161,42 @@ module ELFTools
       # @return [String] The name.
       def name
         @name ||= @symstr.call.name_at(header.st_name)
+      end
+
+      # Return the symbol bind property.
+      # @return [Symbol::Bind] Bind property.
+      def st_bind
+        Bind.new(header.st_info >> 4)
+      end
+
+      # Updates the symbol bind property. Stored in header's st_info high bits.
+      # @param [Symbol::Bind, Integer] bind Bind property.
+      def st_bind=(bind)
+        header.st_info = (header.st_info & 0xf) | (bind.to_i << 4)
+      end
+
+      # Return the symbol type property.
+      # @return [Symbol::Type] type Type property.
+      def st_type
+        Type.new(header.st_info & 0xf)
+      end
+
+      # Updates the symbol type property. Stored in header's st_info low bits.
+      # @param [Symbol::Type, Integer] type Type property.
+      def st_type=(type)
+        header.st_info = (header.st_info & (~0xf)) | (type.to_i & 0xf)
+      end
+
+      # Return the symbol visibility property.
+      # @return [Symbol::Visibility] vis Visibility property.
+      def st_vis
+        Visibility.new(header.st_other & 0x7)
+      end
+
+      # Updates the symbol visibility property. Stored in header's st_other.
+      # @param [Symbol::Visibility, Integer] vis Visibility property.
+      def st_vis=(vis)
+        header.st_other = vis.to_i & 0x7
       end
     end
   end

--- a/spec/enums_spec.rb
+++ b/spec/enums_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'elftools/enums'
+
+class Numbers < Enum
+  enum_attr :first, 1
+  enum_attr :second, 2
+  enum_attr :third, 3
+end
+
+describe Enum do
+  it 'constructs' do
+    n = Numbers
+    expect(n::FIRST).to eq 1
+    expect(n.SECOND).to eq 2
+    expect(n[:third]).to eq 3
+    expect(n.new('third')).to eq 3
+  end
+
+  it 'compares' do
+    n = Numbers
+    expect(n::FIRST).to eq n::FIRST
+    expect(n.SECOND).to eq 2
+    expect(n[:third]).to eq 'third'
+    expect(n.new('third')).to eq :third
+  end
+end

--- a/spec/enums_spec.rb
+++ b/spec/enums_spec.rb
@@ -10,18 +10,23 @@ end
 
 describe Enum do
   it 'constructs' do
-    n = Numbers
-    expect(n::FIRST).to eq 1
-    expect(n.SECOND).to eq 2
-    expect(n[:third]).to eq 3
-    expect(n.new('third')).to eq 3
+    expect(Numbers::FIRST).to eq 1
+    expect(Numbers[1]).to eq 1
+    expect(Numbers.SECOND).to eq 2
+    expect(Numbers[:third]).to eq 3
+    expect(Numbers.new('third')).to eq 3
+    expect { Numbers[:fourth] }.to raise_error(ArgumentError)
+    expect { Numbers.new('fifth') }.to raise_error(ArgumentError)
+    expect { Numbers.new(6) }.to raise_error(ArgumentError)
+    expect { Numbers[7] }.to raise_error(ArgumentError)
   end
 
   it 'compares' do
-    n = Numbers
-    expect(n::FIRST).to eq n::FIRST
-    expect(n.SECOND).to eq 2
-    expect(n[:third]).to eq 'third'
-    expect(n.new('third')).to eq :third
+    expect(Numbers::FIRST).to eq Numbers::FIRST
+    expect(Numbers::FIRST).not_to eq 2
+    expect(Numbers.SECOND).to eq 2
+    expect(Numbers[:third]).to eq 'third'
+    expect(Numbers[:third]).not_to eq 'first'
+    expect(Numbers.new('third')).to eq :third
   end
 end


### PR DESCRIPTION
I do not consider this part of code perfect, yet this is what I came up with to manage elf types more easily. 

I think constants should be accessed with Class::CONSTANT, eg. `Visibility::NONE`, yet these enums currently work only with 
`Visibility.NONE`. I did not fix it, I was short on time. I also don't see clear solution.

What I wanted from these enums:
- fiddle with easily in byebug, cast to string: `puts symbol.st_vis` to print `None` instead of  ... 42 or whatever. 
- use in expressions just as constants before: `symbol.st_vis + 2` to be 44 (or whatever) instead of "None2", currently may require casting with `.to_i`
- allow assigning with symbol `symbol.st_vis = :none`, dunno if works

Part of #52