### PR TITLE
Editable sections data

### DIFF
--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -9,6 +9,8 @@ module ELFTools
     # Class of note section.
     # Note section records notes
     class RelocationSection < Section
+      attr_writer :relocations
+
       # Is this relocation a RELA or REL type.
       # @return [Boolean] If is RELA.
       def rela?
@@ -18,6 +20,8 @@ module ELFTools
       # Number of relocations in this section.
       # @return [Integer] The number.
       def num_relocations
+        return 0 if header.sh_entsize.zero?
+
         header.sh_size / header.sh_entsize
       end
 
@@ -30,7 +34,7 @@ module ELFTools
       #   If +n+ is out of bound, +nil+ is returned.
       def relocation_at(n)
         @relocations ||= LazyArray.new(num_relocations, &method(:create_relocation))
-        @relocations[n]
+        @relocations[n]&.tap { |rel| rel.index = n }
       end
 
       # Iterate all relocations.
@@ -57,15 +61,58 @@ module ELFTools
         each_relocations.to_a
       end
 
+      # Regenereates section's data to be saved in a rebuilt file.
+      # @return [String] Binary representation of section data
+      def rebuild
+        @data = ''
+        each_relocations do |r|
+          @data += r.header.to_binary_s
+        end
+
+        super
+      end
+
+      # Appends new relocation to the section.
+      # Requires ELFFile rebuild to save changes.
+      #
+      # @param [Integer, Relocation32, Relocation64] type Relocation type, stored in header's r_info low bits.
+      # @param [Integer] index Relocation symbol index, stored in header's r_info high bits.
+      # @param [Integer] offset Relocation offset, stored in header's r_offset.
+      # @param [Integer, nil] addend Relocation addend, required iff section is a RELA section.
+      #   Stored in header's r_addend.
+      # @return [Relocation]
+      def append(type:, index:, offset:, addend: nil)
+        raise ArgumentError, "#{addend.nil? ? '' : 'un'}expected addend" if addend.nil? == rela?
+
+        klass = rela? ? Structs::ELF_Rela : Structs::ELF_Rel
+        hdr = klass.new(endian: header.class.self_endian)
+        hdr.elf_class = header.elf_class
+        hdr.r_offset = offset
+        hdr.r_addend = addend if addend
+
+        res = Relocation.new(hdr, stream, self)
+        # TODO: enums based
+        # res.type = type
+        # res.symbol_index = index
+
+        @relocations ||= LazyArray.new(num_relocations, &method(:create_relocation))
+        @relocations.push(res)
+
+        self.data += hdr.to_binary_s
+        header.sh_size += header.sh_entsize
+
+        res
+      end
+
       private
 
       def create_relocation(n)
-        stream.pos = header.sh_offset + n * header.sh_entsize
+        stream.pos = header.sh_offset + n * header.sh_entsize if stream
         klass = rela? ? Structs::ELF_Rela : Structs::ELF_Rel
-        rel = klass.new(endian: header.class.self_endian, offset: stream.pos)
+        rel = klass.new(endian: header.class.self_endian, offset: stream&.pos)
         rel.elf_class = header.elf_class
-        rel.read(stream)
-        Relocation.new(rel, stream)
+        rel.read(stream) if stream
+        Relocation.new(rel, stream, self)
       end
     end
   end
@@ -79,9 +126,17 @@ module ELFTools
     attr_reader :stream # @return [#pos=, #read] Streaming object.
 
     # Instantiate a {Relocation} object.
-    def initialize(header, stream)
+    def initialize(header, stream, section = nil)
       @header = header
       @stream = stream
+      # Proc wrapper used for {ELFFile#loaded_headers} to work
+      @section = section && -> { section }
+    end
+
+    # Returns section containing the relocation.
+    # @return [ELFTools::Sections::RelocationSection] section
+    def section
+      @section.call
     end
 
     # +r_info+ contains sym and type, use two methods
@@ -100,10 +155,13 @@ module ELFTools
     end
     alias type r_info_type
 
-    private
+    def mask_bit(bits = header.elf_class)
+      bits == 32 ? 8 : 32
+    end
 
-    def mask_bit
-      header.elf_class == 32 ? 8 : 32
+    # Returns relocation symbol name read from ".strtab" section at offset from ".symtab"
+    def symbol_name
+      section.elf.symtab.symbols[symbol_index].name
     end
   end
 end

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -3,6 +3,7 @@
 require 'elftools/constants'
 require 'elftools/sections/section'
 require 'elftools/structs'
+require 'elftools/enums'
 
 module ELFTools
   module Sections
@@ -91,9 +92,9 @@ module ELFTools
         hdr.r_addend = addend if addend
 
         res = Relocation.new(hdr, stream, self)
-        # TODO: enums based
-        # res.type = type
-        # res.symbol_index = index
+
+        res.type = type
+        res.symbol_index = index
 
         @relocations ||= LazyArray.new(num_relocations, &method(:create_relocation))
         @relocations.push(res)

--- a/lib/elftools/sections/str_tab_section.rb
+++ b/lib/elftools/sections/str_tab_section.rb
@@ -14,7 +14,24 @@ module ELFTools
       #   Usually from +shdr.sh_name+ or +sym.st_name+.
       # @return [String] The name without null bytes.
       def name_at(offset)
+        return @data[offset...@data.index("\0", offset)] if @data
+
         Util.cstring(stream, header.sh_offset + offset)
+      end
+
+      # Return offset of string in section, appending to section data if necessary.
+      # @param [String] name
+      #   Used for appending new symbols or sections with custom names to {ELFTools::ELFFile}.
+      # @return [Integer] The offset in section at which the name was found or appended.
+      def find_or_insert(name)
+        return 0 if name.empty?
+
+        ind = data.index("#{name}\0")
+        if ind.nil?
+          ind = data.size
+          self.data += "#{name}\0"
+        end
+        ind
       end
     end
   end

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'elftools/sections/section'
+require 'elftools/enums'
 
 module ELFTools
   module Sections
@@ -77,8 +78,8 @@ module ELFTools
         each_symbols do |s|
           @data += s.header.to_binary_s
         end
-        # TODO: requires enums
-        # header.sh_info = symbols.index { |s| s.st_bind == Symbol::Bind.GLOBAL } || num_symbols
+
+        header.sh_info = symbols.index { |s| s.st_bind == Symbol::Bind.GLOBAL } || num_symbols
 
         super
       end
@@ -97,10 +98,10 @@ module ELFTools
         hdr.st_name = elf.strtab.find_or_insert(name)
 
         sym = Symbol.new(hdr, stream, self)
-        # TODO: requires enums
-        # sym.st_bind = bind
-        # sym.st_type = type
-        # sym.st_vis = vis
+
+        sym.st_bind = bind
+        sym.st_type = type
+        sym.st_vis = vis
         sym.index = num_symbols
 
         @symbols ||= LazyArray.new(num_symbols, &method(:create_symbol))

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -8,22 +8,6 @@ module ELFTools
     # Usually for section .symtab and .dynsym,
     # which will refer to symbols in ELF file.
     class SymTabSection < Section
-      # Instantiate a {SymTabSection} object.
-      # There's a +section_at+ lambda for {SymTabSection}
-      # to easily fetch other sections.
-      # @param [ELFTools::Structs::ELF_Shdr] header
-      #   See {Section#initialize} for more information.
-      # @param [#pos=, #read] stream
-      #   See {Section#initialize} for more information.
-      # @param [Proc] section_at
-      #   The method for fetching other sections by index.
-      #   This lambda should be {ELFTools::ELFFile#section_at}.
-      def initialize(header, stream, section_at: nil, **_kwargs)
-        @section_at = section_at
-        # For faster #symbol_by_name
-        super
-      end
-
       # Number of symbols.
       # @return [Integer] The number.
       # @example
@@ -42,7 +26,7 @@ module ELFTools
       #   If +n+ is out of bound, +nil+ is returned.
       def symbol_at(n)
         @symbols ||= LazyArray.new(num_symbols, &method(:create_symbol))
-        @symbols[n]
+        @symbols[n]&.tap { |sym| sym.index = n }
       end
 
       # Iterate all symbols.
@@ -83,7 +67,48 @@ module ELFTools
       # Lazy loaded.
       # @return [ELFTools::Sections::StrTabSection] The string table section.
       def symstr
-        @symstr ||= @section_at.call(header.sh_link)
+        @symstr ||= elf.section_at(header.sh_link)
+      end
+
+      # Regenereates section's data to be saved in a rebuilt file.
+      # @return [String] Binary representation of section data
+      def rebuild
+        @data = ''
+        each_symbols do |s|
+          @data += s.header.to_binary_s
+        end
+        # TODO: requires enums
+        # header.sh_info = symbols.index { |s| s.st_bind == Symbol::Bind.GLOBAL } || num_symbols
+
+        super
+      end
+
+      # Appends new symbol to the section.
+      # Requires ELFFile rebuild to save changes.
+      #
+      # @param [Symbol::Type] type Symbol type, stored in header's st_info
+      # @param [String] name Symbol name, added to ".strtab" section if needed
+      # @param [Symbol::Visibility] vis Symbol visibility, stored in header's st_other
+      # @param [Symbol::Bind] vis Symbol scope, stored in header's st_info
+      # @return [Symbol]
+      def append(type:, name: '', vis: Symbol::Visibility.DEFAULT, bind: Symbol::Bind.LOCAL)
+        hdr = Structs::ELF_sym[elf_class].new(endian: header.class.self_endian)
+        hdr.elf_class = elf_class
+        hdr.st_name = elf.strtab.find_or_insert(name)
+
+        sym = Symbol.new(hdr, stream, self)
+        # TODO: requires enums
+        # sym.st_bind = bind
+        # sym.st_type = type
+        # sym.st_vis = vis
+        sym.index = num_symbols
+
+        @symbols ||= LazyArray.new(num_symbols, &method(:create_symbol))
+        @symbols.push(sym)
+        self.data += sym.header.to_binary_s
+        header.sh_size += header.sh_entsize
+
+        sym
       end
 
       private
@@ -92,7 +117,7 @@ module ELFTools
         stream.pos = header.sh_offset + n * header.sh_entsize
         sym = Structs::ELF_sym[header.elf_class].new(endian: header.class.self_endian, offset: stream.pos)
         sym.read(stream)
-        Symbol.new(sym, stream, symstr: method(:symstr))
+        Symbol.new(sym, stream, self)
       end
     end
 
@@ -102,25 +127,39 @@ module ELFTools
     class Symbol
       attr_reader :header # @return [ELFTools::Structs::ELF32_sym, ELFTools::Structs::ELF64_sym] Section header.
       attr_reader :stream # @return [#pos=, #read] Streaming object.
+      attr_accessor :index # @return [ELFTools::Sections::SymTabSection] Section containing the symbol.
 
       # Instantiate a {ELFTools::Sections::Symbol} object.
       # @param [ELFTools::Structs::ELF32_sym, ELFTools::Structs::ELF64_sym] header
       #   The symbol header.
       # @param [#pos=, #read] stream The streaming object.
-      # @param [ELFTools::Sections::StrTabSection, Proc] symstr
-      #   The symbol string section.
-      #   If +Proc+ is given, it will be called at the first time
-      #   access {Symbol#name}.
-      def initialize(header, stream, symstr: nil)
+      # @param [ELFTools::Sections::SymTabSection, Proc] section
+      #   The section containing this symbol, available for later access with {Symbol#section}.
+      def initialize(header, stream, section)
+        raise ArgumentError, 'Invalid section' unless section.is_a? Section
+
         @header = header
         @stream = stream
-        @symstr = symstr
+        # Proc wrapper used for {ELFFile#loaded_headers} to work
+        @section = section && -> { section }
+      end
+
+      # Returns section containing the symbol.
+      # @return [ELFTools::Sections::SymTabSection] section
+      def section
+        @section.call
       end
 
       # Return the symbol name.
       # @return [String] The name.
       def name
         @name ||= @symstr.call.name_at(header.st_name)
+      end
+
+      # Reads the symbol data from text section at st_shndx.
+      # @return [String] symbol data
+      def data
+        @data ||= section.elf.section_at(header.st_shndx).data[header.st_value, header.st_size]
       end
     end
   end


### PR DESCRIPTION
My assignment was to convert 32-bit obj files to 64-bit and vice-versa, which required fiddling with ELF symbols, relocations, adding new ones, modifying data etc.

Did not find suitable tool (did not look too long, too), decided to go with rbelftools and implement what lacked.

Idea: 
- instead of patches keep full sections data
- allow rebuilding sections
- allow rebuilding whole elf files
- try to keep lazy-loading, even though when saving all data must be loaded anyway
- keep backward compatibility

All in all, I figure it is not that bad of a code.

Assumes #62 to work.

Part of #52. 