### PR TITLE
Fix reinvented to_h

### DIFF
--- a/lib/elftools/structs.rb
+++ b/lib/elftools/structs.rb
@@ -24,7 +24,7 @@ module ELFTools
         @patches ||= {}
       end
 
-      # More like HashWithIndifferentAccess
+      # BinData hash(Snapshot) that behaves like HashWithIndifferentAccess
       alias to_h snapshot
 
       class << self

--- a/lib/elftools/structs.rb
+++ b/lib/elftools/structs.rb
@@ -24,9 +24,8 @@ module ELFTools
         @patches ||= {}
       end
 
-      def to_h
-        field_names.map { |f| [f, send(f)] }.to_h
-      end
+      # More like HashWithIndifferentAccess
+      alias to_h snapshot
 
       class << self
         # Hooks the constructor.

--- a/spec/elf_file_spec.rb
+++ b/spec/elf_file_spec.rb
@@ -156,4 +156,12 @@ describe ELFTools::ELFFile do
       out.close!
     end
   end
+
+  describe 'accessibility' do
+    it 'allows headers to_h' do
+      dyn = @elf.sections_by_type(:dynamic).first.tag_at(0)
+      expect(dyn.header.to_h.keys).to eq [:d_tag, :d_val]
+      expect(dyn.header.to_h.values).to eq [1, 1]
+    end
+  end
 end

--- a/spec/elf_file_spec.rb
+++ b/spec/elf_file_spec.rb
@@ -160,7 +160,7 @@ describe ELFTools::ELFFile do
   describe 'accessibility' do
     it 'allows headers to_h' do
       dyn = @elf.sections_by_type(:dynamic).first.tag_at(0)
-      expect(dyn.header.to_h.keys).to eq [:d_tag, :d_val]
+      expect(dyn.header.to_h.keys).to eq %i[d_tag d_val]
       expect(dyn.header.to_h.values).to eq [1, 1]
     end
   end


### PR DESCRIPTION
turns out bindata objects had 'snapshot' method that returned bindata's custom HashWithIndifferentAccess, aka Snapshot

It works just as expected so changed recent `to_h` to `snapshot` alias