### PR TITLE
Fix off-by-one in offset_from_vma

### DIFF
--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -290,7 +290,7 @@ module ELFTools
     #   elf = ELFTools::ELFFile.new(File.open('/bin/cat'))
     #   elf.offset_from_vma(0x401337)
     #   #=> 4919 # 0x1337
-    def offset_from_vma(vma, size = 0)
+    def offset_from_vma(vma, size = 1)
       segments_by_type(:load) do |seg|
         return seg.vma_to_offset(vma) if seg.vma_in?(vma, size)
       end


### PR DESCRIPTION
Consider the following ELF file:

```
Program Headers:
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
[...]
  LOAD           0x02cfa8 0x000000000002dfa8 0x000000000002dfa8 0x001580 0x002058 RW  0x1000
  LOAD           0x03e000 0x0000000000030000 0x0000000000030000 0x0097c0 0x0097c0 RW  0x1000
[...]
```

Before this pull request, `offset_from_vma(0x30000)` would return `0x2F000` which is a part of the first segment when it instead should be the first offset of the latter segment, i.e. `0x3E000`.

This was due to the default size of zero. `vma_in?` searches from the offset inclusive to the offset + size exclusive. When size = 0 the starting offset is counted as exclusive and thus uses the first segment. For correct calculations, the minimum range must be 1.