### PR TITLE
Pin GitHub Actions versions, other small cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     interval: daily
     time: "21:00"
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,9 +21,11 @@ jobs:
         ruby-version: ['3.2', '3.3', '3.4', head]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@8d27f39a5e7ad39aebbcbd1324f7af020229645c # v1.287.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -31,7 +33,7 @@ jobs:
       run: bundle exec rake
     - name: Publish code coverage
       if: ${{ success() && runner.os == 'Linux' }}
-      uses: qltysh/qlty-action/coverage@v1
+      uses: qltysh/qlty-action/coverage@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
       with:
         oidc: true
         files: coverage/coverage.json


### PR DESCRIPTION
Hi @david942j, thanks for maintaining rbelftools!

I'm one of Homebrew's maintainers and I'm doing some proactive CI/CD security work/cleanup on some of Homebrew's external dependencies, and rbelftools is one of them 🙂 

The changes in this PR are pretty minor:

* All actions are now hash-pinned to make them immutable (Dependabot will keep them updated as normal)
* I've added a cooldown for Ruby dependency bumps in Dependabot
* I've disabled GitHub's default credential persistence with `actions/checkout`, which isn't needed here

These fixes come from [zizmor](https://docs.zizmor.sh), which I maintain. I'd be happy to send a PR enabling zizmor in your CI as well, but I figured it's better to start with just the fixes rather than dumping a new tool on you.

Please let me know if there'a any other information I can provide! I'll be opening a similar PR against your Ruby patchelf repo in a moment.