### PR TITLE
Make LazyArray behave like an array

### DIFF
--- a/lib/elftools/lazy_array.rb
+++ b/lib/elftools/lazy_array.rb
@@ -7,6 +7,9 @@ module ELFTools
   # 'lazy loading' objects.
   # Mainly used when loading sections, segments, and
   # symbols.
+  #
+  # Only {#[]} loads an element on demand, any other method
+  # of +Array+ loads all elements before it operates.
   class LazyArray < SimpleDelegator
     # Instantiate a {LazyArray} object.
     # @param [Integer] size
@@ -28,7 +31,8 @@ module ELFTools
     #   p arr[3]
     #   # 9
     def initialize(size, &block)
-      super(Array.new(size))
+      @array = Array.new(size)
+      super(@array)
       @block = block
     end
 
@@ -36,14 +40,48 @@ module ELFTools
     #
     # Elements are lazy loaded at the first time
     # access it.
+    # @param [Integer] i
+    #   The index, negative index is *not* supported.
     # @return [Object]
     #   The element, returned type is the
     #   return type of block given in {#initialize}.
+    #   +nil+ if +i+ is out of bound.
     def [](i)
-      # XXX: support negative index?
-      return nil unless i.between?(0, __getobj__.size - 1)
+      return nil unless i.between?(0, size - 1)
 
-      __getobj__[i] ||= @block.call(i)
+      @array[i] ||= @block.call(i)
+    end
+
+    # The size of this array.
+    #
+    # This method never loads any element.
+    # @return [Integer]
+    #   The size given in {#initialize}.
+    def size
+      @array.size
+    end
+    alias length size
+
+    # Loads all elements.
+    #
+    # Called whenever a method other than {#[]} and {#size} is invoked, so that
+    # those methods operate on a fully loaded array.
+    # @return [Array]
+    #   The loaded array.
+    # @example
+    #   arr = LazyArray.new(3) { |i| i * i }
+    #   p arr.map { |v| v + 1 }
+    #   # [1, 2, 5]
+    def __getobj__
+      @array.each_index { |i| self[i] }
+      @array
+    end
+
+    private
+
+    # Queries the array without loading any element.
+    def respond_to_missing?(name, include_private = false)
+      @array.respond_to?(name, include_private)
     end
   end
 end

--- a/spec/lazy_array_spec.rb
+++ b/spec/lazy_array_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'elftools/lazy_array'
+
+describe ELFTools::LazyArray do
+  before do
+    @loaded = []
+    @arr = ELFTools::LazyArray.new(3) do |i|
+      @loaded << i
+      i * i
+    end
+  end
+
+  it 'loads on demand' do
+    expect(@arr.size).to be 3
+    expect(@arr.length).to be 3
+    expect(@loaded).to eq []
+
+    expect(@arr[1]).to be 1
+    expect(@loaded).to eq [1]
+
+    # Already loaded elements are not calculated again.
+    expect(@arr[1]).to be 1
+    expect(@loaded).to eq [1]
+  end
+
+  it 'out of bound' do
+    expect(@arr[3]).to be nil
+    # Negative index is not supported.
+    expect(@arr[-1]).to be nil
+    expect(@loaded).to eq []
+  end
+
+  it 'behaves like an array' do
+    expect(@arr.to_a).to eq [0, 1, 4]
+    expect(@arr.map { |v| v + 1 }).to eq [1, 2, 5]
+    expect(@arr.last).to be 4
+    expect(@arr.include?(4)).to be true
+    expect(@arr.inspect).to eq '[0, 1, 4]'
+    # Each element is loaded exactly once.
+    expect(@loaded.sort).to eq [0, 1, 2]
+  end
+
+  it 'responds to array methods without loading' do
+    expect(@arr.respond_to?(:map)).to be true
+    expect(@arr.respond_to?(:no_such_method)).to be false
+    expect(@loaded).to eq []
+  end
+end


### PR DESCRIPTION
Methods other than #[] were delegated to the underlying array before any element got loaded, so they all operated on nils.