### PR TITLE
Name EM_MIPS after the machine alone

### DIFF
--- a/lib/elftools/constants/machine.rb
+++ b/lib/elftools/constants/machine.rb
@@ -15,7 +15,7 @@ module ELFTools
       EM_88K               = 5      # Motorola m88k family
       EM_IAMCU             = 6      # Intel MCU
       EM_860               = 7      # Intel 80860
-      EM_MIPS              = 8      # MIPS R3000 (officially, big-endian only)
+      EM_MIPS              = 8      # MIPS R3000
       EM_S370              = 9      # IBM System/370
       EM_MIPS_RS3_LE       = 10     # MIPS R3000 little-endian (Oct 4 1999 Draft). Deprecated
       EM_PARISC            = 15     # HPPA

--- a/lib/elftools/constants/machine_names.rb
+++ b/lib/elftools/constants/machine_names.rb
@@ -19,7 +19,7 @@ module ELFTools
         EM_88K => 'Motorola m88k family',
         EM_IAMCU => 'Intel MCU',
         EM_860 => 'Intel 80860',
-        EM_MIPS => 'MIPS R3000 (officially, big-endian only)',
+        EM_MIPS => 'MIPS R3000',
         EM_S370 => 'IBM System/370',
         EM_MIPS_RS3_LE => 'MIPS R3000 little-endian (Oct 4 1999 Draft). Deprecated',
         EM_PARISC => 'HPPA',

--- a/spec/constants_spec.rb
+++ b/spec/constants_spec.rb
@@ -14,7 +14,7 @@ describe ELFTools::Constants do
     expect(em.mapping(0)).to eq 'No machine'
     expect(em.mapping(3)).to eq 'Intel 80386'
     expect(em.mapping(7)).to eq 'Intel 80860'
-    expect(em.mapping(8)).to eq 'MIPS R3000 (officially, big-endian only)'
+    expect(em.mapping(8)).to eq 'MIPS R3000'
     expect(em.mapping(20)).to eq 'PowerPC'
     expect(em.mapping(21)).to eq '64-bit PowerPC'
     expect(em.mapping(40)).to eq 'ARM'

--- a/spec/cross_arch_spec.rb
+++ b/spec/cross_arch_spec.rb
@@ -14,8 +14,8 @@ describe 'cross architecture files' do
     'arm.thumb.o' => [32, :little, 'REL', 'ARM'],
     'riscv64.elf' => [64, :little, 'DYN', 'RISC-V'],
     'ppc64.elf' => [64, :big, 'DYN', '64-bit PowerPC'],
-    'mips.o' => [32, :big, 'REL', 'MIPS R3000 (officially, big-endian only)'],
-    'mips64.o' => [64, :big, 'REL', 'MIPS R3000 (officially, big-endian only)']
+    'mips.o' => [32, :big, 'REL', 'MIPS R3000'],
+    'mips64.o' => [64, :big, 'REL', 'MIPS R3000']
   }.each do |name, (elf_class, endian, type, machine)|
     it name do
       file = elf(name)

--- a/tasks/gen_constants.rake
+++ b/tasks/gen_constants.rake
@@ -14,9 +14,14 @@ module Gen
   # is a value that predates the ABI and that the registry reserves as well.
   MACHINE_IGNORED = /\AEM_(NUM|res\d+|OLD_SPARCV9)\z/
 
-  # Constants binutils defines without describing them anywhere. A constant
-  # binutils describes is reported so that the entry can be dropped.
+  # Descriptions recorded here instead of by binutils, which describes some
+  # constants nowhere and describes others as more than the name of a machine.
+  # An entry binutils has come to describe the same way is reported so that it
+  # can be dropped.
   MACHINE_DESCRIPTIONS = {
+    # binutils appends a note that the machine is officially big endian only,
+    # which the little endian files recording it contradict.
+    'EM_MIPS' => 'MIPS R3000',
     'EM_XSTORMY16' => 'Sanyo XStormy16 CPU core'
   }.freeze
 
@@ -229,12 +234,13 @@ namespace :gen do
     end
   end
 
-  # Fills in the descriptions binutils doesn't carry.
+  # Records the descriptions binutils doesn't carry, and the ones it carries
+  # differently.
   def describe(definitions)
     Gen::MACHINE_DESCRIPTIONS.each do |name, description|
       value, text = definitions[name]
       raise "#{name} is not defined anymore, drop it from MACHINE_DESCRIPTIONS" if value.nil?
-      raise "#{name} is described as #{text.inspect} now, drop it from MACHINE_DESCRIPTIONS" if text
+      raise "#{name} is described as #{text.inspect} now, drop it from MACHINE_DESCRIPTIONS" if text == description
 
       definitions[name] = [value, description]
     end


### PR DESCRIPTION
binutils describes it as "MIPS R3000 (officially, big-endian only)", a note that reads as part of the name once ELFFile#machine returns it, and that the little endian files recording EM_MIPS contradict anyway. The name is now MIPS R3000, which is what the hand-maintained table returned before the names came from binutils.

MACHINE_DESCRIPTIONS, until now the descriptions binutils carries nowhere, is what records it. An entry earns its place by describing a machine differently than binutils does, which is what the generator checks for.