### PR TITLE
Read the download count off shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Downloads](https://img.shields.io/endpoint?url=https://gem-badge-h3lg.onrender.com/downloads/elftools)](https://rubygems.org/gems/elftools)
+[![Downloads](https://img.shields.io/gem/dt/elftools)](https://rubygems.org/gems/elftools)
 
 [![Gem Version](https://badge.fury.io/rb/elftools.svg)](https://badge.fury.io/rb/elftools)
 [![Build Status](https://github.com/david942j/rbelftools/workflows/build/badge.svg)](https://github.com/david942j/rbelftools/actions)


### PR DESCRIPTION
The badge went through a shim that answers "Count not found" now, so the README showed "custom badge: resource not found" where a number belongs. shields.io counts a gem's downloads itself, which is what one_gadget's badge asks for.