### PR TITLE
Name the type, binding, and visibility of a symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ entries here are collected from those announcements and from the commit history.
 - `Sections::Symbol#type`, `#bind`, `#visibility`, and `#section_index`, which decode
   `st_info` and `st_other`, together with the `Constants::STV` visibilities
   ([#89](https://github.com/david942j/rbelftools/pull/89))
+- `Sections::Symbol#type_name`, `#bind_name`, and `#visibility_name`, and
+  `Constants::Naming` behind them, which names a value after the constants defining it.
+  Several may define one, a machine naming a value for itself and a name marking where a
+  range begins rather than naming anything, so `STT_ARM_TFUNC` and `STT_SPARC_REGISTER`
+  are told apart and `STT_GNU_IFUNC` is named over the `STT_LOOS` it shares a value with
+  ([#101](https://github.com/david942j/rbelftools/pull/101))
 - 42 more `Constants::EM` constants, `EM_RISCV`, `EM_LOONGARCH`, and `EM_IAMCU` among
   them ([#92](https://github.com/david942j/rbelftools/pull/92))
 - `ELFFile#machine` names 229 machines, where it used to name 11 and answer

--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ symtab_section.symbol_by_name('puts@@GLIBC_2.2.5').section_index == ELFTools::Co
 #=> true
 ```
 
+Each of those has a name. Several constants may define one value, so naming it takes
+the machine of the file, which names some of them for itself.
+```ruby
+[main.type_name, main.bind_name, main.visibility_name]
+#=> ["STT_FUNC", "STB_GLOBAL", "STV_DEFAULT"]
+
+# 13 is a symbol type ARM and SPARC each define, and no one else names.
+ELFTools::Constants::STT.mapping(ELFTools::Constants::EM_ARM, 13)
+#=> "STT_ARM_TFUNC"
+ELFTools::Constants::STT.mapping(ELFTools::Constants::EM_X86_64, 13)
+#=> "<unknown>: 0xd"
+```
+
 ## Segments
 
 ```ruby

--- a/lib/elftools/constants.rb
+++ b/lib/elftools/constants.rb
@@ -11,6 +11,70 @@ module ELFTools
     # ELF magic header
     ELFMAG = "\x7FELF"
 
+    # Names a value after the constants that define it, for the modules where
+    # several of them may define one value.
+    #
+    # A machine defines names of its own, and a name may mark where a range of
+    # values begins or ends, or how many of them are defined, rather than name
+    # one of them.
+    module Naming
+      # Architectures a constant can be named after, the longest first so that
+      # a name is read as the architecture it spells out in full.
+      ARCHITECTURES = (R.constants - [:MACHINES]).sort_by { |name| -name.length }.freeze
+
+      # Return the name of +value+.
+      #
+      # Names of a machine other than +machine+ are passed over, as are the
+      # ones that mark a range or a count instead of naming a value.
+      # @param [Integer?] machine Value of +e_machine+.
+      # @param [Integer] value The value to name.
+      # @return [String] The name.
+      # @example
+      #   Constants::STT.mapping(Constants::EM_ARM, 13)
+      #   #=> 'STT_ARM_TFUNC'
+      #   Constants::STT.mapping(Constants::EM_X86_64, 13)
+      #   #=> '<unknown>: 0xd'
+      def mapping(machine, value)
+        architecture = R::MACHINES[machine]
+        name = names_by_value.fetch(value, []).find do |constant|
+          !marker?(constant) && [nil, architecture].include?(architecture_of(constant))
+        end
+        name ? name.to_s : format('<unknown>: 0x%x', value)
+      end
+
+      private
+
+      # The constants defining each value, in the order they are defined.
+      # @return [Hash{Integer => Array<Symbol>}] The constants.
+      def names_by_value
+        @names_by_value ||= constants.group_by { |constant| const_get(constant) }
+      end
+
+      # The architecture a constant is named after.
+      # @example
+      #   architecture_of(:SHN_MIPS_ACOMMON)
+      #   #=> :MIPS
+      #   architecture_of(:SHN_ABS)
+      #   #=> nil
+      # @return [Symbol?] The architecture, +nil+ if the name spells out none.
+      def architecture_of(constant)
+        rest = constant.to_s.sub(/\A#{name.split('::').last}_/, '')
+        ARCHITECTURES.find { |architecture| rest.start_with?("#{architecture}_") }
+      end
+
+      # Whether a constant marks where a range of values begins or ends, or
+      # how many of them are defined, rather than naming one of them.
+      # @example
+      #   marker?(:STT_LOPROC)
+      #   #=> true
+      #   marker?(:STT_FUNC)
+      #   #=> false
+      # @return [Boolean] The answer.
+      def marker?(constant)
+        constant.to_s.match?(/_((LO|HI)(OS|PROC|RESERVE)|NUM)\z/)
+      end
+    end
+
     # Values of `d_un.d_val' in the DT_FLAGS and DT_FLAGS_1 entry.
     module DF
       DF_ORIGIN       = 0x00000001 # Object may use DF_ORIGIN
@@ -328,6 +392,8 @@ module ELFTools
     # Special indices to section. These are used when there is no valid index to section header.
     # The meaning of these values is left upto the embedding header.
     module SHN
+      extend Naming
+
       SHN_UNDEF           = 0      # undefined section
       SHN_LORESERVE       = 0xff00 # start of reserved indices
 
@@ -484,6 +550,8 @@ module ELFTools
 
     # Symbol binding from Sym st_info field.
     module STB
+      extend Naming
+
       STB_LOCAL      = 0 # Local symbol
       STB_GLOBAL     = 1 # Global symbol
       STB_WEAK       = 2 # Weak symbol
@@ -498,6 +566,8 @@ module ELFTools
 
     # Symbol types from Sym st_info field.
     module STT
+      extend Naming
+
       STT_NOTYPE         = 0 # Symbol type is unspecified
       STT_OBJECT         = 1 # Symbol is a data object
       STT_FUNC           = 2 # Symbol is a code object
@@ -531,6 +601,8 @@ module ELFTools
 
     # Symbol visibility from Sym st_other field.
     module STV
+      extend Naming
+
       STV_DEFAULT   = 0 # Visibility is specified by binding type
       STV_INTERNAL  = 1 # OS specific version of {STV_HIDDEN}
       STV_HIDDEN    = 2 # Can only be seen inside currently compilation unit

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -19,8 +19,12 @@ module ELFTools
       # @param [Proc] section_at
       #   The method for fetching other sections by index.
       #   This lambda should be {ELFTools::ELFFile#section_at}.
-      def initialize(header, stream, section_at: nil, **_kwargs)
+      # @param [Integer] machine
+      #   The machine of the ELF file, which decides what the fields of a
+      #   symbol mean. This should be +e_machine+ of the ELF header.
+      def initialize(header, stream, section_at: nil, machine: nil, **_kwargs)
         @section_at = section_at
+        @machine = machine
         # For faster #symbol_by_name
         super
       end
@@ -93,7 +97,7 @@ module ELFTools
         stream.pos = header.sh_offset + n * header.sh_entsize
         sym = Structs::ELF_sym[header.elf_class].new(endian: header.class.self_endian, offset: stream.pos)
         sym.read(stream)
-        Symbol.new(sym, stream, symstr: method(:symstr))
+        Symbol.new(sym, stream, symstr: method(:symstr), machine: @machine)
       end
     end
   end

--- a/lib/elftools/sections/symbol.rb
+++ b/lib/elftools/sections/symbol.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'elftools/constants'
+
 module ELFTools
   module Sections
     # Class of symbol.
@@ -15,10 +17,13 @@ module ELFTools
       #   The symbol string section.
       #   If +Proc+ is given, it will be called at the first time
       #   access {Symbol#name}.
-      def initialize(header, stream, symstr: nil)
+      # @param [Integer] machine
+      #   The machine of the ELF file, which a name of a value depends on.
+      def initialize(header, stream, symstr: nil, machine: nil)
         @header = header
         @stream = stream
         @symstr = symstr
+        @machine = machine
       end
 
       # Return the symbol name.
@@ -38,6 +43,18 @@ module ELFTools
         header.st_info & 0xf
       end
 
+      # The name of {#type}.
+      #
+      # A machine names types of its own, so the name is only known when the
+      # machine of the file is.
+      # @return [String] The name.
+      # @example
+      #   symbol.type_name
+      #   #=> 'STT_FUNC'
+      def type_name
+        Constants::STT.mapping(@machine, type)
+      end
+
       # How this symbol is linked against others with the same name.
       #
       # The available bindings are listed in {ELFTools::Constants::STB}.
@@ -47,6 +64,15 @@ module ELFTools
       #   #=> true
       def bind
         header.st_info >> 4
+      end
+
+      # The name of {#bind}.
+      # @return [String] The name.
+      # @example
+      #   symbol.bind_name
+      #   #=> 'STB_GLOBAL'
+      def bind_name
+        Constants::STB.mapping(@machine, bind)
       end
 
       # How this symbol is accessed once it becomes part of an executable or
@@ -59,6 +85,15 @@ module ELFTools
       #   #=> true
       def visibility
         header.st_other & 0x3
+      end
+
+      # The name of {#visibility}.
+      # @return [String] The name.
+      # @example
+      #   symbol.visibility_name
+      #   #=> 'STV_DEFAULT'
+      def visibility_name
+        Constants::STV.mapping(@machine, visibility)
       end
 
       # The index of the section this symbol is defined in.

--- a/spec/constants_spec.rb
+++ b/spec/constants_spec.rb
@@ -38,4 +38,40 @@ describe ELFTools::Constants do
     expect(et.mapping(3)).to eq 'DYN'
     expect(et.mapping(4)).to eq 'CORE'
   end
+
+  describe ELFTools::Constants::Naming do
+    let(:c) { ELFTools::Constants }
+
+    it 'names a value after the machine that defines it' do
+      # 13 is a type each of these machines defines for itself.
+      expect(c::STT.mapping(c::EM_ARM, 13)).to eq 'STT_ARM_TFUNC'
+      expect(c::STT.mapping(c::EM_SPARC, 13)).to eq 'STT_SPARC_REGISTER'
+      expect(c::SHN.mapping(c::EM_MIPS, 0xff02)).to eq 'SHN_MIPS_DATA'
+      expect(c::SHN.mapping(c::EM_X86_64, 0xff02)).to eq 'SHN_X86_64_LCOMMON'
+    end
+
+    it 'passes over the names of another machine' do
+      expect(c::STT.mapping(c::EM_X86_64, 13)).to eq '<unknown>: 0xd'
+      expect(c::SHN.mapping(c::EM_ARM, 0xff02)).to eq '<unknown>: 0xff02'
+      # Nothing names a value when the machine is unknown either.
+      expect(c::STT.mapping(nil, 13)).to eq '<unknown>: 0xd'
+    end
+
+    it 'passes over a name marking a range or a count' do
+      # STT_LOOS and STB_LOOS mark where a range begins, the value is named
+      # after what defines it. STT_NUM and SHN_LORESERVE only ever mark.
+      expect(c::STT.mapping(c::EM_X86_64, 10)).to eq 'STT_GNU_IFUNC'
+      expect(c::STB.mapping(c::EM_X86_64, 10)).to eq 'STB_GNU_UNIQUE'
+      expect(c::SHN.mapping(c::EM_X86_64, 0xffff)).to eq 'SHN_XINDEX'
+      expect(c::STT.mapping(c::EM_X86_64, 7)).to eq '<unknown>: 0x7'
+      expect(c::SHN.mapping(c::EM_X86_64, 0xff00)).to eq '<unknown>: 0xff00'
+    end
+
+    it 'names what only one constant defines' do
+      expect(c::STT.mapping(c::EM_X86_64, 2)).to eq 'STT_FUNC'
+      expect(c::STB.mapping(c::EM_X86_64, 0)).to eq 'STB_LOCAL'
+      expect(c::STV.mapping(c::EM_X86_64, 2)).to eq 'STV_HIDDEN'
+      expect(c::SHN.mapping(c::EM_X86_64, 0xfff1)).to eq 'SHN_ABS'
+    end
+  end
 end

--- a/spec/symbol_spec.rb
+++ b/spec/symbol_spec.rb
@@ -26,6 +26,22 @@ describe ELFTools::Sections::Symbol do
     expect(@symtab.symbol_by_name('__dso_handle').visibility).to be ELFTools::Constants::STV_HIDDEN
   end
 
+  it 'names what it decodes' do
+    main = @symtab.symbol_by_name('main')
+    expect([main.type_name, main.bind_name, main.visibility_name]).to eq %w[STT_FUNC STB_GLOBAL STV_DEFAULT]
+    expect(@symtab.symbol_by_name('crtstuff.c').type_name).to eq 'STT_FILE'
+    expect(@symtab.symbol_by_name('__gmon_start__').bind_name).to eq 'STB_WEAK'
+    expect(@symtab.symbol_by_name('__dso_handle').visibility_name).to eq 'STV_HIDDEN'
+  end
+
+  it 'names a type only the OS defining it records' do
+    filepath = File.join(__dir__, 'files', 'libc.so.6')
+    dynsym = ELFTools::ELFFile.new(File.open(filepath)).section_by_name('.dynsym')
+    ifunc = dynsym.symbols.find { |symbol| symbol.type == ELFTools::Constants::STT_GNU_IFUNC }
+    # The value is STT_LOOS as well, which only marks where a range begins.
+    expect(ifunc.type_name).to eq 'STT_GNU_IFUNC'
+  end
+
   it 'section_index' do
     # Symbols to be resolved at runtime are not defined in any section.
     expect(@symtab.symbol_by_name('puts@@GLIBC_2.2.5').section_index).to be ELFTools::Constants::SHN_UNDEF


### PR DESCRIPTION
Naming any of them means choosing between the constants that define one value, which #89 left undone. A machine names a value for itself, so that 13 is STT_ARM_TFUNC or STT_SPARC_REGISTER depending on the file and nothing to the machines that leave the range alone. A name may also mark where a range begins or ends, or how many values are defined, rather than name one, so STT_GNU_IFUNC is the name of the value it shares with STT_LOOS, and STT_NUM names nothing.

Constants::Naming does the choosing, reading the machine of a name off the architectures Constants::R already lists. STT, STB, STV, and SHN extend it, of which the first three are what the new Symbol methods ask.