### PR TITLE
Read the dynamic tags a file is loaded by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ entries here are collected from those announcements and from the commit history.
 - `Sections::Symbol#type`, `#bind`, `#visibility`, and `#section_index`, which decode
   `st_info` and `st_other`, together with the `Constants::STV` visibilities
   ([#89](https://github.com/david942j/rbelftools/pull/89))
+- `ELFFile#dynamic`, the dynamic tags of a file read from the view its type makes
+  authoritative. An executable or a shared object is loaded by its segments, so the
+  segment answers and the section recording the same tags is metadata; a relocatable
+  file has no segments, so its sections do
+  ([#102](https://github.com/david942j/rbelftools/pull/102))
 - `Sections::Symbol#type_name`, `#bind_name`, and `#visibility_name`, and
   `Constants::Naming` behind them, which names a value after the constants defining it.
   Several may define one, a machine naming a value for itself and a name marking where a

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -59,6 +59,25 @@ module ELFTools
       note.desc.unpack1('H*')
     end
 
+    # The dynamic tags of this file, read from the view that its type makes
+    # authoritative.
+    #
+    # A relocatable file is linked by its sections, so its sections answer and
+    # any segment it carries is disregarded, being something no linker reads.
+    # An executable or a shared object is loaded by its segments alone, so the
+    # segment answers and the section recording the same tags is metadata a
+    # tool may have stripped or rewritten.
+    # @return [ELFTools::Segments::DynamicSegment, ELFTools::Sections::DynamicSection, nil]
+    #   The tags, +nil+ if the view that decides records none.
+    # @example
+    #   elf.dynamic.tag_by_type(:needed).name
+    #   #=> 'libc.so.6'
+    def dynamic
+      return sections_by_type(:dynamic).first if header.e_type.to_i == Constants::ET_REL
+
+      segment_by_type(:dynamic) || sections_by_type(:dynamic).first
+    end
+
     # Get machine architecture.
     #
     # Mappings of architecture can be found

--- a/spec/elf_file_spec.rb
+++ b/spec/elf_file_spec.rb
@@ -1,6 +1,7 @@
 # encoding: ascii-8bit
 # frozen_string_literal: true
 
+require 'stringio'
 require 'tempfile'
 
 require 'elftools/elf_file'
@@ -145,6 +146,57 @@ describe ELFTools::ELFFile do
 
     it 'when invalid address' do
       expect(@elf.vma_from_offset(0x12345678)).to eq(nil)
+    end
+  end
+
+  describe 'dynamic' do
+    def elf(name)
+      described_class.new(File.open(File.join(__dir__, 'files', name)))
+    end
+
+    # Returns an ELF file whose header has been modified by +block+.
+    # @yieldparam [ELFTools::Structs::ELF_Ehdr] header The ELF header.
+    # @yieldreturn [void]
+    # @return [ELFTools::ELFFile]
+    def elf_with_patched_header(name)
+      data = File.binread(File.join(__dir__, 'files', name))
+      header = described_class.new(StringIO.new(data)).header
+      yield header
+      data[0, header.num_bytes] = header.to_binary_s
+      described_class.new(StringIO.new(data))
+    end
+
+    it 'reads the tags a loaded file is loaded by' do
+      # An executable and a shared object record the same tags twice, and the
+      # segment is the one the kernel and the loader read.
+      %w[amd64.elf libc.so.6].each do |name|
+        file = elf(name)
+        expect(file.dynamic).to be_a ELFTools::Segments::DynamicSegment
+        expect(file.dynamic.tags.size).to eq file.section_by_name('.dynamic').tags.size
+      end
+    end
+
+    it 'reads none from a file that records none' do
+      # A relocatable file is linked by its sections and has no segments.
+      expect(elf('mips64.o').segments).to be_empty
+      expect(elf('mips64.o').dynamic).to be nil
+    end
+
+    it 'disregards the segments of a file that says it is relocatable' do
+      # Segments on an object file are something no linker reads, forged or
+      # left over, and the sections are what governs it either way.
+      file = elf_with_patched_header('amd64.elf') { |header| header.e_type = ELFTools::Constants::ET_REL }
+      expect(file.segment_by_type(:dynamic)).not_to be nil
+      expect(file.dynamic).to be_a ELFTools::Sections::DynamicSection
+    end
+
+    it 'falls back to the section of a file that has no segments' do
+      file = elf_with_patched_header('amd64.elf') { |header| header.e_phnum = 0 }
+      expect(file.segments).to be_empty
+      expect(file.dynamic).to be_a ELFTools::Sections::DynamicSection
+      expect(file.dynamic.tags.size).to eq elf('amd64.elf').dynamic.tags.size
+      # A tag names a string by address, which only the segments resolve.
+      expect { file.dynamic.tag_by_type(:needed).name }.to raise_error ELFTools::ELFError
     end
   end
 


### PR DESCRIPTION
Which of the two views of an ELF file is the truth depends on what the file is. A relocatable file is linked by its sections, and the linker reads no segments at all: an object carrying one is malformed or forged, and its sections govern it either way. An executable or a shared object is loaded by its segments alone, the kernel reading e_phoff and never opening the section table, so a file whose section headers are gone still runs and one whose program headers are gone is not executable.

ELFFile#dynamic answers with the view that decides, which is what reading the tables the tags point at has to start from.