### PR TITLE
Read the relocations the dynamic tags point at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ entries here are collected from those announcements and from the commit history.
 - `Sections::Symbol#type`, `#bind`, `#visibility`, and `#section_index`, which decode
   `st_info` and `st_other`, together with the `Constants::STV` visibilities
   ([#89](https://github.com/david942j/rbelftools/pull/89))
+- `Dynamic#relocations`, the relocations the tags of a file point at, which is where a
+  file that has been stripped of its sections still records them. They are read from
+  `DT_REL` or `DT_RELA` and from `DT_JMPREL`, and are the same relocations the
+  `.rel(a).dyn` and `.rel(a).plt` sections record
+  ([#103](https://github.com/david942j/rbelftools/pull/103))
 - `ELFFile#dynamic`, the dynamic tags of a file read from the view its type makes
   authoritative. An executable or a shared object is loaded by its segments, so the
   segment answers and the section recording the same tags is metadata; a relocatable

--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ relocation = mips.sections_by_type(:rela).first.relocations.first
 #=> [8, "R_MIPS_GPREL16"]
 ```
 
+A relocation is recorded twice in a file that is loaded, and the tags are the copy the
+loader reads, so they answer even when the sections have been stripped away.
+```ruby
+elf.dynamic.relocations.size
+#=> 8
+elf.dynamic.relocations.map(&:type_name).uniq
+#=> ["R_X86_64_GLOB_DAT", "R_X86_64_COPY", "R_X86_64_JUMP_SLOT"]
+```
+
 ## Patch
 
 Patch ELF is so easy!

--- a/lib/elftools/constants.rb
+++ b/lib/elftools/constants.rb
@@ -119,6 +119,8 @@ module ELFTools
 
     # Dynamic table types, records in +d_tag+.
     module DT
+      extend Naming
+
       DT_NULL                       = 0 # marks the end of the _DYNAMIC array
       DT_NEEDED                     = 1 # libraries need to be linked by loader
       DT_PLTRELSZ                   = 2 # total size of relocation entries

--- a/lib/elftools/dynamic.rb
+++ b/lib/elftools/dynamic.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require 'elftools/constants'
 require 'elftools/exceptions'
+require 'elftools/relocation'
+require 'elftools/structs'
 
 module ELFTools
   # Define common methods for dynamic sections and dynamic segments.
@@ -105,10 +108,76 @@ module ELFTools
       @tag_at_map[n] = Tag.new(dyn.read(stream), stream, method(:str_offset))
     end
 
+    # The relocations the tags point at.
+    #
+    # Two tables record them: the one +DT_REL+ or +DT_RELA+ names, and the one
+    # +DT_JMPREL+ names, whose entries are of the kind +DT_PLTREL+ names.
+    # @return [Array<ELFTools::Relocation>] The relocations, in the order the
+    #   tags record them.
+    # @raise [ELFTools::ELFError]
+    #   If a table is not in any loadable segment.
+    # @example
+    #   elf.dynamic.relocations.map(&:type_name).uniq
+    #   #=> ['R_X86_64_GLOB_DAT', 'R_X86_64_JUMP_SLOT']
+    def relocations
+      relocation_tables.flat_map { |start, size, rela| read_relocations(start, size, rela) }
+    end
+
     private
 
     def endian
       header.class.self_endian
+    end
+
+    # Where each table of relocations starts, the tag recording how many bytes
+    # it takes, and whether its entries record an addend.
+    # @return [Array<Array(ELFTools::Dynamic::Tag, ELFTools::Dynamic::Tag, Boolean)>] The tables.
+    def relocation_tables
+      tables = %i[rel rela].filter_map do |type|
+        tag = tag_by_type(type)
+        [tag, tag_by_type(:"#{type}sz"), type == :rela] if tag
+      end
+      jmprel = tag_by_type(:jmprel)
+      return tables if jmprel.nil?
+
+      tables << [jmprel, tag_by_type(:pltrelsz), tag_by_type(:pltrel).header.d_val.to_i == Constants::DT_RELA]
+    end
+
+    # Reads one table of relocations.
+    # @return [Array<ELFTools::Relocation>] The relocations.
+    def read_relocations(start, size, rela)
+      klass = rela ? Structs::ELF_Rela : Structs::ELF_Rel
+      offset = offset_of(start)
+      # An entry takes what its structure takes. DT_RELAENT and DT_RELENT
+      # record the same number, which a file has no way of disagreeing with
+      # and every file here agrees with.
+      entsize = entry(klass).num_bytes
+      Array.new(size.header.d_val.to_i / entsize) do |i|
+        rel = entry(klass)
+        rel.offset = offset + (i * entsize)
+        stream.pos = rel.offset
+        rel.read(stream)
+        Relocation.new(rel, stream, machine: @machine)
+      end
+    end
+
+    # An entry of a table, of the structure and the class the file records it in.
+    # @return [ELFTools::Structs::ELF_Rel, ELFTools::Structs::ELF_Rela] The entry.
+    def entry(klass)
+      entry = klass.new(endian:)
+      entry.elf_class = header.elf_class
+      entry
+    end
+
+    # The file offset the address a tag records points at.
+    # @param [ELFTools::Dynamic::Tag] tag The tag.
+    # @return [Integer] The file offset.
+    # @raise [ELFTools::ELFError]
+    #   If the address is not in any loadable segment.
+    def offset_of(tag)
+      vma = tag.header.d_val.to_i
+      @offset_from_vma.call(vma) ||
+        raise(ELFError, format('Invalid %s address 0x%x', Constants::DT.mapping(@machine, tag.header.d_tag.to_i), vma))
     end
 
     # Get the DT_STRTAB's +d_val+ offset related to file.
@@ -120,8 +189,7 @@ module ELFTools
         strtab = tag_by_type(:strtab)
         raise ELFError, 'DT_STRTAB not found' if strtab.nil?
 
-        vma = strtab.header.d_val.to_i
-        @offset_from_vma.call(vma) || raise(ELFError, format('Invalid DT_STRTAB address 0x%x', vma))
+        offset_of(strtab)
       end
     end
 

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -410,7 +410,9 @@ module ELFTools
       stream.pos = header.e_phoff + n * header.e_phentsize
       phdr = Structs::ELF_Phdr[elf_class].new(endian:, offset: stream.pos)
       phdr.elf_class = elf_class
-      Segments::Segment.create(phdr.read(stream), stream, offset_from_vma: method(:offset_from_vma))
+      Segments::Segment.create(phdr.read(stream), stream,
+                               offset_from_vma: method(:offset_from_vma),
+                               machine: header.e_machine.to_i)
     end
   end
 end

--- a/lib/elftools/sections/dynamic_section.rb
+++ b/lib/elftools/sections/dynamic_section.rb
@@ -12,6 +12,19 @@ module ELFTools
     class DynamicSection < Section
       include ELFTools::Dynamic
 
+      # Instantiate a {DynamicSection} object.
+      # @param [ELFTools::Structs::ELF_Shdr] header
+      #   See {Section#initialize} for more information.
+      # @param [#pos=, #read] stream
+      #   See {Section#initialize} for more information.
+      # @param [Integer] machine
+      #   The machine of the ELF file, which decides what the entries a tag
+      #   points at mean. This should be +e_machine+ of the ELF header.
+      def initialize(header, stream, machine: nil, **_kwargs)
+        @machine = machine
+        super
+      end
+
       # Get the start address of tags.
       # @return [Integer] Start address of tags.
       def tag_start

--- a/lib/elftools/segments/segment.rb
+++ b/lib/elftools/segments/segment.rb
@@ -14,10 +14,14 @@ module ELFTools
       #   Streaming object.
       # @param [Method] offset_from_vma
       #   The method to get offset of file, given virtual memory address.
-      def initialize(header, stream, offset_from_vma: nil)
+      # @param [Integer] machine
+      #   The machine of the ELF file, which decides what the entries a
+      #   segment points at mean. This should be +e_machine+ of the ELF header.
+      def initialize(header, stream, offset_from_vma: nil, machine: nil, **_kwargs)
         @header = header
         @stream = stream
         @offset_from_vma = offset_from_vma
+        @machine = machine
       end
 
       # Return +header.p_type+ in a simpler way.

--- a/spec/dynamic_spec.rb
+++ b/spec/dynamic_spec.rb
@@ -44,6 +44,51 @@ describe ELFTools::Dynamic do
     end
   end
 
+  describe 'relocations' do
+    def elf(name)
+      ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', name)))
+    end
+
+    def from_sections(file)
+      file.sections.select { |sec| sec.is_a?(ELFTools::Sections::RelocationSection) }.flat_map(&:relocations)
+    end
+
+    def summarize(relocations)
+      relocations.map { |rel| [rel.header.r_offset.to_i, rel.symbol_index, rel.type_name] }
+    end
+
+    it 'reads what the sections record' do
+      # Both views describe the same bytes, so each answers for the other.
+      %w[amd64.elf i386.elf aarch64.elf ppc64.elf libc.so.6].each do |name|
+        file = elf(name)
+        expect(summarize(file.dynamic.relocations)).to eq summarize(from_sections(file))
+        expect(file.dynamic.relocations).not_to be_empty
+      end
+    end
+
+    it 'reads them from a file that has no sections left' do
+      data = File.binread(File.join(__dir__, 'files', 'amd64.elf'))
+      header = ELFTools::ELFFile.new(StringIO.new(data)).header
+      header.e_shoff = 0
+      header.e_shnum = 0
+      header.e_shstrndx = 0
+      data[0, header.num_bytes] = header.to_binary_s
+      file = ELFTools::ELFFile.new(StringIO.new(data))
+      expect(file.sections).to be_empty
+      expect(summarize(file.dynamic.relocations)).to eq summarize(from_sections(elf('amd64.elf')))
+    end
+
+    it 'reports a table that is not loaded' do
+      data = File.binread(File.join(__dir__, 'files', 'amd64.elf'))
+      tag = ELFTools::ELFFile.new(StringIO.new(data)).dynamic.tag_by_type(:jmprel)
+      tag.header.d_val = 0xdeadbeef000
+      data[tag.header.offset, tag.header.num_bytes] = tag.header.to_binary_s
+      file = ELFTools::ELFFile.new(StringIO.new(data))
+      expect { file.dynamic.relocations }
+        .to raise_error(ELFTools::ELFError, 'Invalid DT_JMPREL address 0xdeadbeef000')
+    end
+  end
+
   describe 'broken DT_STRTAB' do
     # Returns an ELF file whose DT_STRTAB tag has been modified by +block+.
     # @yieldparam [ELFTools::Structs::ELF_Dyn] header The DT_STRTAB header.


### PR DESCRIPTION
The tags name two tables of them, the one DT_REL or DT_RELA records and the one DT_JMPREL does, and record how many bytes each takes, so both are read exactly rather than counted. They are the same relocations the .rel(a).dyn and .rel(a).plt sections record, which every file here confirms entry for entry, and they are still there to read once a file has been stripped of its sections.

Segments carry the machine now, as sections have since #95, because naming a relocation type takes it.