### PR TITLE
Read the symbols the dynamic tags point at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ entries here are collected from those announcements and from the commit history.
 - `Sections::Symbol#type`, `#bind`, `#visibility`, and `#section_index`, which decode
   `st_info` and `st_other`, together with the `Constants::STV` visibilities
   ([#89](https://github.com/david942j/rbelftools/pull/89))
+- `Dynamic#symbols`, `#symbol_at`, `#symbol_by_name`, and `#num_symbols`, the symbols the
+  tags of a file point at, which is where a file that has been stripped of its sections
+  still records them. Nothing a file is loaded by records how large that table is, because
+  the loader looks a name up through a hash table and jumps straight to an index rather
+  than ever enumerating it, so the count is how far `DT_HASH`, `DT_GNU_HASH`, and the
+  relocations reach between them, and is a lower bound where only the latter two answer.
+  `#symbol_at` needs no count and is exact for any index
+  ([#104](https://github.com/david942j/rbelftools/pull/104))
 - `Dynamic#relocations`, the relocations the tags of a file point at, which is where a
   file that has been stripped of its sections still records them. They are read from
   `DT_REL` or `DT_RELA` and from `DT_JMPREL`, and are the same relocations the

--- a/README.md
+++ b/README.md
@@ -126,6 +126,28 @@ ELFTools::Constants::STT.mapping(ELFTools::Constants::EM_X86_64, 13)
 #=> "<unknown>: 0xd"
 ```
 
+The symbols a file is loaded by are recorded twice, and the tags are the copy the loader
+reads, so they answer even when the sections have been stripped away. Naming the symbol a
+relocation points at takes nothing but the tags.
+```ruby
+dynamic = elf.dynamic
+dynamic.symbols.map(&:name).reject(&:empty?).first(4).join(' ')
+#=> "puts __stack_chk_fail printf __libc_start_main"
+dynamic.symbol_by_name('printf').type_name
+#=> "STT_FUNC"
+dynamic.relocations.map { |rel| dynamic.symbol_at(rel.symbol_index).name }.first(3)
+#=> ["__gmon_start__", "stdin", "puts"]
+```
+
+Nothing a file is loaded by records how large its symbol table is, because the loader
+looks a name up through a hash table and jumps straight to an index rather than ever
+enumerating it. `num_symbols` is therefore how far the hash table and the relocations
+reach between them, which is a lower bound, while `symbol_at` is exact for any index.
+```ruby
+dynamic.num_symbols
+#=> 9
+```
+
 ## Segments
 
 ```ruby

--- a/lib/elftools/dynamic.rb
+++ b/lib/elftools/dynamic.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'elftools/constants'
+require 'elftools/dynamic/string_table'
+require 'elftools/dynamic/symbols'
+require 'elftools/dynamic/tag'
 require 'elftools/exceptions'
 require 'elftools/relocation'
 require 'elftools/structs'
@@ -13,6 +16,8 @@ module ELFTools
   #   and {ELFTools::Segments::DynamicSegment} because methods here assume some
   #   attributes exist.
   module Dynamic
+    include Symbols
+
     # Iterate all tags.
     #
     # @note
@@ -105,7 +110,7 @@ module ELFTools
       dyn.elf_class = header.elf_class
       stream.pos = tag_start + n * dyn.num_bytes
       dyn.offset = stream.pos
-      @tag_at_map[n] = Tag.new(dyn.read(stream), stream, method(:str_offset))
+      @tag_at_map[n] = Tag.new(dyn.read(stream), stream, string_table)
     end
 
     # The relocations the tags point at.
@@ -151,22 +156,30 @@ module ELFTools
       # An entry takes what its structure takes. DT_RELAENT and DT_RELENT
       # record the same number, which a file has no way of disagreeing with
       # and every file here agrees with.
-      entsize = entry(klass).num_bytes
+      entsize = struct(klass).num_bytes
       Array.new(size.header.d_val.to_i / entsize) do |i|
-        rel = entry(klass)
-        rel.offset = offset + (i * entsize)
-        stream.pos = rel.offset
-        rel.read(stream)
-        Relocation.new(rel, stream, machine: @machine)
+        Relocation.new(read_struct(klass, offset + (i * entsize)), stream, machine: @machine)
       end
     end
 
-    # An entry of a table, of the structure and the class the file records it in.
-    # @return [ELFTools::Structs::ELF_Rel, ELFTools::Structs::ELF_Rela] The entry.
-    def entry(klass)
-      entry = klass.new(endian:)
-      entry.elf_class = header.elf_class
-      entry
+    # A structure of the endianness and the class the file records it in.
+    # @param [Class] klass The structure class.
+    # @return [ELFTools::Structs::ELFStruct] The structure, before it is read.
+    def struct(klass)
+      struct = klass.new(endian:)
+      struct.elf_class = header.elf_class
+      struct
+    end
+
+    # Reads a structure the file records at a file offset.
+    # @param [Class] klass The structure class.
+    # @param [Integer] offset The file offset.
+    # @return [ELFTools::Structs::ELFStruct] The structure.
+    def read_struct(klass, offset)
+      struct = struct(klass)
+      struct.offset = offset
+      stream.pos = offset
+      struct.read(stream)
     end
 
     # The file offset the address a tag records points at.
@@ -180,6 +193,12 @@ module ELFTools
         raise(ELFError, format('Invalid %s address 0x%x', Constants::DT.mapping(@machine, tag.header.d_tag.to_i), vma))
     end
 
+    # The names the tags and the symbols point at.
+    # @return [ELFTools::Dynamic::StringTable] The string table.
+    def string_table
+      @string_table ||= StringTable.new(stream, method(:str_offset))
+    end
+
     # Get the DT_STRTAB's +d_val+ offset related to file.
     # @return [Integer] The file offset.
     # @raise [ELFTools::ELFError]
@@ -190,66 +209,6 @@ module ELFTools
         raise ELFError, 'DT_STRTAB not found' if strtab.nil?
 
         offset_of(strtab)
-      end
-    end
-
-    # A tag class.
-    class Tag
-      attr_reader :header # @return [ELFTools::Structs::ELF_Dyn] The dynamic tag header.
-      attr_reader :stream # @return [#pos=, #read] Streaming object.
-
-      # Instantiate a {ELFTools::Dynamic::Tag} object.
-      # @param [ELF_Dyn] header The dynamic tag header.
-      # @param [#pos=, #read] stream Streaming object.
-      # @param [Method] str_offset
-      #   Call this method to get the string offset related
-      #   to file.
-      def initialize(header, stream, str_offset)
-        @header = header
-        @stream = stream
-        @str_offset = str_offset
-      end
-
-      # Some dynamic have name.
-      TYPE_WITH_NAME = [Constants::DT_NEEDED,
-                        Constants::DT_SONAME,
-                        Constants::DT_RPATH,
-                        Constants::DT_RUNPATH].freeze
-      # Return the content of this tag records.
-      #
-      # For normal tags, this method just return
-      # +header.d_val+. For tags with +header.d_val+
-      # in meaning of string offset (e.g. DT_NEEDED), this method would
-      # return the string it specified.
-      # Tags with type in {TYPE_WITH_NAME} are those tags with name.
-      # @return [Integer, String] The content this tag records.
-      # @example
-      #   dynamic = elf.segment_by_type(:dynamic)
-      #   dynamic.tag_by_type(:init).value
-      #   #=> 4195600 # 0x400510
-      #   dynamic.tag_by_type(:needed).value
-      #   #=> 'libc.so.6'
-      def value
-        name || header.d_val.to_i
-      end
-
-      # Is this tag has a name?
-      #
-      # The criteria here is if this tag's type is in {TYPE_WITH_NAME}.
-      # @return [Boolean] Is this tag has a name.
-      def name?
-        TYPE_WITH_NAME.include?(header.d_tag)
-      end
-
-      # Return the name of this tag.
-      #
-      # Only tags with name would return a name.
-      # Others would return +nil+.
-      # @return [String, nil] The name.
-      def name
-        return nil unless name?
-
-        Util.cstring(stream, @str_offset.call + header.d_val.to_i)
       end
     end
   end

--- a/lib/elftools/dynamic/string_table.rb
+++ b/lib/elftools/dynamic/string_table.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'elftools/util'
+
+module ELFTools
+  module Dynamic
+    # The names a file records, which the tags point at rather than a section.
+    #
+    # Answers what {ELFTools::Sections::StrTabSection} answers, so that what is
+    # read from the tags names itself the way what is read from the sections
+    # does.
+    class StringTable
+      # Instantiate a {ELFTools::Dynamic::StringTable} object.
+      # @param [#pos=, #read] stream Streaming object.
+      # @param [Method] offset
+      #   Call this method to get the file offset the table starts at.
+      def initialize(stream, offset)
+        @stream = stream
+        @offset = offset
+      end
+
+      # Return the name recorded at an offset into the table.
+      # @param [Integer] offset Usually from +tag.d_val+ or +sym.st_name+.
+      # @return [String] The name without null bytes.
+      def name_at(offset)
+        Util.cstring(@stream, @offset.call + offset)
+      end
+    end
+  end
+end

--- a/lib/elftools/dynamic/symbols.rb
+++ b/lib/elftools/dynamic/symbols.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'elftools/exceptions'
+require 'elftools/sections/symbol'
+require 'elftools/structs'
+
+module ELFTools
+  module Dynamic
+    # The symbols a file is loaded by, which the tags point at.
+    #
+    # @note
+    #   This module is included by {ELFTools::Dynamic} and reads through the
+    #   methods there, so it cannot be included on its own.
+    module Symbols
+      # Get the +n+-th symbol.
+      #
+      # Symbols are lazy loaded.
+      # @note
+      #   We cannot do bound checking of +n+ here, because nothing records how
+      #   many symbols there are. {#num_symbols} is a lower bound rather than a
+      #   bound, so checking against it would hide symbols this method reads
+      #   correctly.
+      # @param [Integer] n The index.
+      # @return [ELFTools::Sections::Symbol] The desired symbol.
+      # @raise [ELFTools::ELFError]
+      #   If +DT_SYMTAB+ is absent, or its address is not in any loadable segment.
+      def symbol_at(n)
+        return if n.negative?
+
+        @symbol_at_map ||= {}
+        @symbol_at_map[n] ||= begin
+          klass = Structs::ELF_sym[header.elf_class]
+          # An entry takes what its structure takes, which is also what
+          # DT_SYMENT records and what a file has no way of disagreeing with.
+          sym = read_struct(klass, sym_offset + (n * struct(klass).num_bytes))
+          Sections::Symbol.new(sym, stream, symstr: method(:string_table), machine: @machine)
+        end
+      end
+
+      # How many symbols the tags reach.
+      #
+      # Nothing a file is loaded by records how large its symbol table is. The
+      # loader never enumerates it: it looks a name up through a hash table and
+      # jumps straight to an index, so where the table ends is none of its
+      # business. Two things bound it instead, the hash table that indexes the
+      # names a file exports and the relocations that name a symbol by index,
+      # and the answer is how far the further of the two reaches. Only +DT_HASH+
+      # records the number outright.
+      #
+      # This is therefore a lower bound. A symbol that is neither indexed by the
+      # hash table nor named by a relocation is invisible to both, and is
+      # missing from the count. {#symbol_at} is exact for any index.
+      # @return [Integer] The number.
+      # @example
+      #   elf.dynamic.num_symbols
+      #   #=> 9
+      def num_symbols
+        @num_symbols ||= [count_from_hash, count_from_gnu_hash, count_from_relocations].compact.max || 0
+      end
+
+      # Iterate all symbols.
+      #
+      # Symbols are lazy loaded, so {#symbol_by_name} only creates the symbols
+      # it has to look at.
+      # @yieldparam [ELFTools::Sections::Symbol] symbol A symbol object.
+      # @yieldreturn [void]
+      # @return [Enumerator<ELFTools::Sections::Symbol>, Array<ELFTools::Sections::Symbol>]
+      #   If block is not given, an enumerator will be returned.
+      #   Otherwise, return array of symbols.
+      def each_symbols(&block)
+        return enum_for(:each_symbols) unless block_given?
+
+        Array.new(num_symbols) { |i| symbol_at(i).tap(&block) }
+      end
+
+      # The symbols the tags point at, which is where a file that has been
+      # stripped of its sections still records them.
+      #
+      # As many of them as {#num_symbols} reaches.
+      # @return [Array<ELFTools::Sections::Symbol>] The symbols.
+      # @example
+      #   elf.dynamic.symbols.map(&:name)
+      #   #=> ['', 'puts', '__stack_chk_fail', 'printf', '__libc_start_main']
+      def symbols
+        each_symbols.to_a
+      end
+
+      # Get symbol by its name.
+      #
+      # Only the symbols {#symbols} reaches are searched.
+      # @param [String] name The name of symbol.
+      # @return [ELFTools::Sections::Symbol, nil] The desired symbol.
+      def symbol_by_name(name)
+        each_symbols.find { |symbol| symbol.name == name }
+      end
+
+      private
+
+      # How many symbols +DT_HASH+ records, which is exact: a chain of the table
+      # belongs to every symbol, whether the table indexes it or not.
+      # @return [Integer, nil] The number, +nil+ if the tag is absent.
+      def count_from_hash
+        tag = tag_by_type(:hash)
+        return if tag.nil?
+
+        read_struct(Structs::ELF_Hash, offset_of(tag)).nchain.to_i
+      end
+
+      # How far +DT_GNU_HASH+ reaches, i.e. the highest index it indexes plus
+      # one. It only ever indexes the defined symbols a file exports under a
+      # name, and the symbols before +symndx+ are by construction not among
+      # them.
+      # @return [Integer, nil] The number, +nil+ if the tag is absent.
+      def count_from_gnu_hash
+        tag = tag_by_type(:gnu_hash)
+        return if tag.nil?
+
+        base = offset_of(tag)
+        head = read_struct(Structs::ELF_GnuHash, base)
+        buckets = base + head.num_bytes + (head.maskwords.to_i * header.elf_class / 8)
+        last = Array.new(head.nbuckets.to_i) { |i| read_word(buckets + (i * 4)) }.max || 0
+        return head.symndx.to_i if last < head.symndx.to_i
+
+        chain = buckets + (head.nbuckets.to_i * 4)
+        # The chain of a bucket runs on until an entry has its lowest bit set.
+        n = last - head.symndx.to_i
+        n += 1 while read_word(chain + (n * 4)).even?
+        head.symndx.to_i + n + 1
+      end
+
+      # How far the relocations reach, i.e. the highest index they name plus one.
+      # They only ever name the symbols something in the file refers to.
+      # @return [Integer, nil] The number, +nil+ if none names a symbol.
+      def count_from_relocations
+        highest = relocations.map(&:symbol_index).max
+        highest && highest + 1
+      end
+
+      # Reads a word, the unit a hash table lays its entries out in.
+      # @param [Integer] offset The file offset.
+      # @return [Integer] The word.
+      def read_word(offset)
+        stream.pos = offset
+        stream.read(4).unpack1(endian == :big ? 'N' : 'V')
+      end
+
+      # Get the +DT_SYMTAB+'s +d_val+ offset related to file.
+      # @return [Integer] The file offset.
+      # @raise [ELFTools::ELFError]
+      #   If +DT_SYMTAB+ is absent, or its address is not in any loadable segment.
+      def sym_offset
+        @sym_offset ||= begin
+          symtab = tag_by_type(:symtab)
+          raise ELFError, 'DT_SYMTAB not found' if symtab.nil?
+
+          offset_of(symtab)
+        end
+      end
+    end
+  end
+end

--- a/lib/elftools/dynamic/tag.rb
+++ b/lib/elftools/dynamic/tag.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'elftools/constants'
+
+module ELFTools
+  module Dynamic
+    # A tag class.
+    class Tag
+      attr_reader :header # @return [ELFTools::Structs::ELF_Dyn] The dynamic tag header.
+      attr_reader :stream # @return [#pos=, #read] Streaming object.
+
+      # Instantiate a {ELFTools::Dynamic::Tag} object.
+      # @param [ELF_Dyn] header The dynamic tag header.
+      # @param [#pos=, #read] stream Streaming object.
+      # @param [ELFTools::Dynamic::StringTable] strtab
+      #   The string table the names of tags are recorded in.
+      def initialize(header, stream, strtab)
+        @header = header
+        @stream = stream
+        @strtab = strtab
+      end
+
+      # Some dynamic have name.
+      TYPE_WITH_NAME = [Constants::DT_NEEDED,
+                        Constants::DT_SONAME,
+                        Constants::DT_RPATH,
+                        Constants::DT_RUNPATH].freeze
+      # Return the content of this tag records.
+      #
+      # For normal tags, this method just return
+      # +header.d_val+. For tags with +header.d_val+
+      # in meaning of string offset (e.g. DT_NEEDED), this method would
+      # return the string it specified.
+      # Tags with type in {TYPE_WITH_NAME} are those tags with name.
+      # @return [Integer, String] The content this tag records.
+      # @example
+      #   dynamic = elf.segment_by_type(:dynamic)
+      #   dynamic.tag_by_type(:init).value
+      #   #=> 4195600 # 0x400510
+      #   dynamic.tag_by_type(:needed).value
+      #   #=> 'libc.so.6'
+      def value
+        name || header.d_val.to_i
+      end
+
+      # Is this tag has a name?
+      #
+      # The criteria here is if this tag's type is in {TYPE_WITH_NAME}.
+      # @return [Boolean] Is this tag has a name.
+      def name?
+        TYPE_WITH_NAME.include?(header.d_tag)
+      end
+
+      # Return the name of this tag.
+      #
+      # Only tags with name would return a name.
+      # Others would return +nil+.
+      # @return [String, nil] The name.
+      def name
+        return nil unless name?
+
+        @strtab.name_at(header.d_val.to_i)
+      end
+    end
+  end
+end

--- a/lib/elftools/structs.rb
+++ b/lib/elftools/structs.rb
@@ -184,6 +184,22 @@ module ELFTools
       64 => ELF64_sym
     }.freeze
 
+    # Header of the symbol hash table +DT_HASH+ points at.
+    class ELF_Hash < ELFStruct
+      endian :big_and_little
+      uint32 :nbucket # Number of buckets
+      uint32 :nchain  # Number of chains, which is how many symbols there are
+    end
+
+    # Header of the symbol hash table +DT_GNU_HASH+ points at.
+    class ELF_GnuHash < ELFStruct
+      endian :big_and_little
+      uint32 :nbuckets  # Number of buckets
+      uint32 :symndx    # The first symbol index the table indexes
+      uint32 :maskwords # Number of words the bloom filter takes
+      uint32 :shift2    # The second shift the bloom filter is built with
+    end
+
     # Note header.
     class ELF_Nhdr < ELFStruct
       endian :big_and_little

--- a/spec/dynamic_spec.rb
+++ b/spec/dynamic_spec.rb
@@ -5,6 +5,22 @@ require 'stringio'
 require 'elftools/elf_file'
 
 describe ELFTools::Dynamic do
+  def elf(name)
+    ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', name)))
+  end
+
+  # Reads +name+ with its section headers taken away, as a packer or a dumper
+  # leaves a file that still runs.
+  def elf_without_sections(name)
+    data = File.binread(File.join(__dir__, 'files', name))
+    header = ELFTools::ELFFile.new(StringIO.new(data)).header
+    header.e_shoff = 0
+    header.e_shnum = 0
+    header.e_shstrndx = 0
+    data[0, header.num_bytes] = header.to_binary_s
+    ELFTools::ELFFile.new(StringIO.new(data))
+  end
+
   before(:all) do
     filepath = File.join(__dir__, 'files', 'amd64.elf')
     @elf = ELFTools::ELFFile.new(File.open(filepath))
@@ -45,10 +61,6 @@ describe ELFTools::Dynamic do
   end
 
   describe 'relocations' do
-    def elf(name)
-      ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', name)))
-    end
-
     def from_sections(file)
       file.sections.select { |sec| sec.is_a?(ELFTools::Sections::RelocationSection) }.flat_map(&:relocations)
     end
@@ -67,13 +79,7 @@ describe ELFTools::Dynamic do
     end
 
     it 'reads them from a file that has no sections left' do
-      data = File.binread(File.join(__dir__, 'files', 'amd64.elf'))
-      header = ELFTools::ELFFile.new(StringIO.new(data)).header
-      header.e_shoff = 0
-      header.e_shnum = 0
-      header.e_shstrndx = 0
-      data[0, header.num_bytes] = header.to_binary_s
-      file = ELFTools::ELFFile.new(StringIO.new(data))
+      file = elf_without_sections('amd64.elf')
       expect(file.sections).to be_empty
       expect(summarize(file.dynamic.relocations)).to eq summarize(from_sections(elf('amd64.elf')))
     end
@@ -86,6 +92,92 @@ describe ELFTools::Dynamic do
       file = ELFTools::ELFFile.new(StringIO.new(data))
       expect { file.dynamic.relocations }
         .to raise_error(ELFTools::ELFError, 'Invalid DT_JMPREL address 0xdeadbeef000')
+    end
+  end
+
+  describe 'symbols' do
+    it 'reads what .dynsym records' do
+      # .dynsym describes the very bytes the tags point at, so it answers for
+      # them, name for name and index for index. Every file here that is
+      # loaded is checked, i.e. every one with dynamic tags.
+      loaded = %w[aarch64.elf amd64.elf amd64.frelro.elf amd64.nrelro.elf amd64.strip.elf arm.elf
+                  i386.elf i386.pie.elf i386.so.elf libc.so.6 ppc64.elf riscv64.elf]
+      loaded.each do |name|
+        file = elf(name)
+        dynsym = file.section_by_name('.dynsym')
+        expect(file.dynamic.num_symbols).to eq dynsym.num_symbols
+        expect(file.dynamic.symbols.map(&:name)).to eq dynsym.symbols.map(&:name)
+        expect(file.dynamic.symbols.map(&:header)).to eq dynsym.symbols.map(&:header)
+      end
+    end
+
+    it 'counts what no single source of a count can' do
+      # Neither source sees the whole table. A hash table only indexes the
+      # defined symbols a file exports under a name, so ppc64.elf's reaches 1
+      # of its 13; relocations only name the symbols something refers to, so
+      # i386.so.elf's reach 16 of its 20. Together they have covered every
+      # file here.
+      expect(elf('ppc64.elf').dynamic.num_symbols).to eq 13
+      expect(elf('i386.so.elf').dynamic.num_symbols).to eq 20
+      # DT_HASH is the one tag that records the number outright.
+      expect(elf('libc.so.6').dynamic.tag_by_type(:hash)).not_to be nil
+      expect(elf('libc.so.6').dynamic.num_symbols).to eq 2245
+    end
+
+    it 'names the symbol a relocation points at' do
+      dynamic = elf('amd64.elf').dynamic
+      expect(dynamic.relocations.map { |rel| dynamic.symbol_at(rel.symbol_index).name }).to eq \
+        %w[__gmon_start__ stdin puts __stack_chk_fail printf __libc_start_main fgets scanf]
+    end
+
+    it 'symbol_at' do
+      dynamic = elf('amd64.elf').dynamic
+      expect(dynamic.symbol_at(0).name).to eq ''
+      expect(dynamic.symbol_at(1).name).to eq 'puts'
+      expect(dynamic.symbol_at(1)).to be dynamic.symbol_at(1)
+      expect(dynamic.symbol_at(-1)).to be nil
+    end
+
+    it 'symbol_by_name' do
+      dynamic = elf('amd64.elf').dynamic
+      expect(dynamic.symbol_by_name('printf').type_name).to eq 'STT_FUNC'
+      expect(dynamic.symbol_by_name('no such symbol')).to be nil
+    end
+
+    it 'each_symbols' do
+      dynamic = elf('amd64.elf').dynamic
+      expect(dynamic.each_symbols).to be_a Enumerator
+      expect(dynamic.each_symbols.map(&:name)).to eq dynamic.symbols.map(&:name)
+    end
+
+    it 'reads them from a file that has no sections left' do
+      file = elf_without_sections('amd64.elf')
+      expect(file.sections).to be_empty
+      expect(file.dynamic.symbols.map(&:name)).to eq elf('amd64.elf').section_by_name('.dynsym').symbols.map(&:name)
+    end
+
+    it 'reports a table that is not there' do
+      # Change the tag type so that DT_SYMTAB no longer exists.
+      file = elf_with_patched_symtab { |header| header.d_tag = ELFTools::Constants::DT_DEBUG }
+      expect { file.dynamic.symbol_at(0) }.to raise_error(ELFTools::ELFError, 'DT_SYMTAB not found')
+    end
+
+    it 'reports a table that is not loaded' do
+      file = elf_with_patched_symtab { |header| header.d_val = 0xdeadbeef000 }
+      expect { file.dynamic.symbol_at(0) }.to \
+        raise_error(ELFTools::ELFError, 'Invalid DT_SYMTAB address 0xdeadbeef000')
+    end
+
+    # Returns an ELF file whose DT_SYMTAB tag has been modified by +block+.
+    # @yieldparam [ELFTools::Structs::ELF_Dyn] header The DT_SYMTAB header.
+    # @yieldreturn [void]
+    # @return [ELFTools::ELFFile]
+    def elf_with_patched_symtab
+      data = File.binread(File.join(__dir__, 'files', 'amd64.elf'))
+      header = ELFTools::ELFFile.new(StringIO.new(data)).dynamic.tag_by_type(:symtab).header
+      yield header
+      data[header.offset, header.num_bytes] = header.to_binary_s
+      ELFTools::ELFFile.new(StringIO.new(data))
     end
   end
 


### PR DESCRIPTION
They are the symbols .dynsym records, which every file here confirms name for name, and they are still there to read once a file has been stripped of its sections. Naming the symbol a relocation points at takes nothing but the tags now.

Nothing a file is loaded by records how large the table is: the loader looks a name up through a hash table and jumps straight to an index, so where the table ends is none of its business. Two things bound it, the hash table and the relocations that name a symbol by index, and neither alone is enough. A hash table only indexes the defined symbols a file exports under a name, so ppc64.elf's reaches 1 of its 13; relocations only name what something refers to, so i386.so.elf's reach 16 of its 20. Together they have covered all twelve loaded files. DT_HASH records the number outright, and one file here has it.

The count is therefore a lower bound, documented as one, while symbol_at needs no count and is exact for any index.

Tag moves to a file of its own alongside the new ones, and takes the string table the tags and the symbols share rather than an offset.