### PR TITLE
Look a dynamic symbol name up the way the loader does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ entries here are collected from those announcements and from the commit history.
 - `Sections::Symbol#type`, `#bind`, `#visibility`, and `#section_index`, which decode
   `st_info` and `st_other`, together with the `Constants::STV` visibilities
   ([#89](https://github.com/david942j/rbelftools/pull/89))
+- `Dynamic#symbol_by_name` looks a name up through `DT_HASH` or `DT_GNU_HASH`, which is what
+  the loader itself does, instead of reading every symbol until it finds the name. Neither
+  table indexes every symbol, and a file need not record either, so a name a table does not
+  lead to is still searched for
+  ([#105](https://github.com/david942j/rbelftools/pull/105))
 - `Dynamic#symbols`, `#symbol_at`, `#symbol_by_name`, and `#num_symbols`, the symbols the
   tags of a file point at, which is where a file that has been stripped of its sections
   still records them. Nothing a file is loaded by records how large that table is, because

--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ dynamic.num_symbols
 #=> 9
 ```
 
+Looking a name up is what the loader does through a hash table, rather than searching the
+symbol table for it, and `symbol_by_name` does the same wherever the file records one. A
+table only indexes the names a file exports, so a name it does not lead to, and a file
+that records no table at all, are searched for instead.
+```ruby
+libc = ELFTools::ELFFile.new(File.open('spec/files/libc.so.6'))
+# Reached through DT_HASH, without reading any of the other 2244 symbols.
+libc.dynamic.symbol_by_name('malloc').type_name
+#=> "STT_FUNC"
+```
+
 ## Segments
 
 ```ruby

--- a/lib/elftools/dynamic/hash_table.rb
+++ b/lib/elftools/dynamic/hash_table.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require 'elftools/structs'
+
+module ELFTools
+  module Dynamic
+    # A table of names the loader looks a symbol up in, instead of searching
+    # the symbol table for it.
+    #
+    # A file records one of two kinds, or both of them. Both answer the same
+    # two questions, how far the symbol table they index reaches and which
+    # index a name sits at, and differ in how they are laid out, in how they
+    # hash a name, and in which symbols they index at all.
+    class HashTable
+      # Instantiate a {ELFTools::Dynamic::HashTable} object.
+      # @param [#pos=, #read] stream Streaming object.
+      # @param [Integer] offset The file offset the table starts at.
+      # @param [Integer] elf_class 32 or 64, the width of a mask of the table.
+      # @param [Symbol] endian +:little+ or +:big+.
+      def initialize(stream, offset, elf_class:, endian:)
+        @stream = stream
+        @offset = offset
+        @elf_class = elf_class
+        @endian = endian
+      end
+
+      private
+
+      # The header the table starts with.
+      # @return [ELFTools::Structs::ELFStruct] The header.
+      def header
+        @header ||= begin
+          @stream.pos = @offset
+          self.class::HEADER.new(endian: @endian).read(@stream)
+        end
+      end
+
+      # Reads the four-byte word at an offset into the table, the unit buckets
+      # and chains are laid out in.
+      # @param [Integer] offset The offset into the table.
+      # @return [Integer] The word.
+      def word_at(offset)
+        read_at(offset, 4)
+      end
+
+      # Reads an unsigned integer at an offset into the table.
+      # @param [Integer] offset The offset into the table.
+      # @param [Integer] bytes How many bytes it takes, 4 or 8.
+      # @return [Integer] The integer.
+      def read_at(offset, bytes)
+        @stream.pos = @offset + offset
+        @stream.read(bytes).unpack1("#{bytes == 4 ? 'L' : 'Q'}#{@endian == :big ? '>' : '<'}")
+      end
+
+      # The table +DT_HASH+ points at, which the System V ABI defines.
+      #
+      # A chain of it belongs to every symbol, so it is the one table that
+      # records how many there are.
+      class SysV < HashTable
+        # The header the table starts with.
+        HEADER = Structs::ELF_Hash
+
+        # How many symbols the table is built over, which it records outright.
+        # @return [Integer] The number.
+        def num_symbols
+          header.nchain.to_i
+        end
+
+        # The index a name sits at.
+        #
+        # A bucket leads to a chain of the indices whose names hash alike, so
+        # the block is what tells them apart.
+        # @param [String] name The name.
+        # @yieldparam [Integer] index An index whose name hashes like +name+.
+        # @yieldreturn [Boolean] Whether the symbol there is the one wanted.
+        # @return [Integer, nil]
+        #   The index, +nil+ if the table does not lead to the name.
+        def index_of(name)
+          return if header.nbucket.to_i.zero?
+
+          n = word_at(buckets + ((hash_of(name) % header.nbucket.to_i) * 4))
+          # Index zero is the undefined symbol, so it ends a chain instead of
+          # belonging to one.
+          while n.positive? && n < num_symbols
+            return n if yield(n)
+
+            n = word_at(chain + (n * 4))
+          end
+        end
+
+        private
+
+        # Where the buckets start, as an offset into the table.
+        # @return [Integer] The offset.
+        def buckets
+          header.num_bytes
+        end
+
+        # Where the chains start, as an offset into the table.
+        # @return [Integer] The offset.
+        def chain
+          buckets + (header.nbucket.to_i * 4)
+        end
+
+        # The hash the System V ABI defines, which keeps a name in 28 bits.
+        # @param [String] name The name.
+        # @return [Integer] The hash.
+        def hash_of(name)
+          name.each_byte.reduce(0) do |h, c|
+            h = (h << 4) + c
+            top = h & 0xf000_0000
+            (h ^ (top >> 24)) & ~top
+          end
+        end
+      end
+
+      # The table +DT_GNU_HASH+ points at.
+      #
+      # It only indexes the defined symbols a file exports under a name, and
+      # the symbols before {#symndx} are by construction not among them, so a
+      # name it does not lead to may still be in the symbol table.
+      class Gnu < HashTable
+        # The header the table starts with.
+        HEADER = Structs::ELF_GnuHash
+
+        # How far the table reaches, i.e. the highest index it indexes plus one.
+        # @return [Integer] The number.
+        def num_symbols
+          last = Array.new(header.nbuckets.to_i) { |i| word_at(buckets + (i * 4)) }.max || 0
+          return symndx if last < symndx
+
+          n = last - symndx
+          n += 1 while word_at(chain + (n * 4)).even?
+          symndx + n + 1
+        end
+
+        # The index a name sits at.
+        #
+        # A bucket leads to a chain of the indices whose names hash alike, so
+        # the block is what tells them apart.
+        # @param [String] name The name.
+        # @yieldparam [Integer] index An index whose name hashes like +name+.
+        # @yieldreturn [Boolean] Whether the symbol there is the one wanted.
+        # @return [Integer, nil]
+        #   The index, +nil+ if the table does not lead to the name.
+        def index_of(name, &block)
+          return if header.nbuckets.to_i.zero? || header.maskwords.to_i.zero?
+
+          h = hash_of(name)
+          return unless may_index?(h)
+
+          n = word_at(buckets + ((h % header.nbuckets.to_i) * 4))
+          return if n.zero? || n < symndx
+
+          walk(n, h, &block)
+        end
+
+        private
+
+        # The first symbol index the table indexes.
+        # @return [Integer] The index.
+        def symndx
+          header.symndx.to_i
+        end
+
+        # Where the buckets start, as an offset into the table.
+        # @return [Integer] The offset.
+        def buckets
+          header.num_bytes + (header.maskwords.to_i * @elf_class / 8)
+        end
+
+        # Where the chains start, as an offset into the table.
+        # @return [Integer] The offset.
+        def chain
+          buckets + (header.nbuckets.to_i * 4)
+        end
+
+        # Walks the chain a bucket leads to, whose entries are the hashes of
+        # the names it holds, with the lowest bit marking the last of them.
+        # @param [Integer] index The index the bucket leads to.
+        # @param [Integer] hash The hash of the name wanted.
+        # @return [Integer, nil] The index, +nil+ if the chain ends without it.
+        def walk(index, hash)
+          loop do
+            # The lowest bit belongs to the chain rather than to the hash.
+            value = word_at(chain + ((index - symndx) * 4))
+            return index if (value | 1) == (hash | 1) && yield(index)
+            break if value.odd?
+
+            index += 1
+          end
+        end
+
+        # Whether the filter in front of the table rules a hash out, which it
+        # answers for a name the file does not export without the table being
+        # read at all. Looking a name up across a chain of files is what it is
+        # there for.
+        # @param [Integer] hash The hash.
+        # @return [Boolean] Whether the name may be indexed.
+        def may_index?(hash)
+          width = @elf_class / 8
+          word = read_at(header.num_bytes + (((hash / @elf_class) % header.maskwords.to_i) * width), width)
+          mask = (1 << (hash % @elf_class)) | (1 << ((hash >> header.shift2.to_i) % @elf_class))
+          word & mask == mask
+        end
+
+        # The hash GNU defines, which is djb2.
+        # @param [String] name The name.
+        # @return [Integer] The hash.
+        def hash_of(name)
+          name.each_byte.reduce(5381) { |h, c| ((h * 33) + c) & 0xffff_ffff }
+        end
+      end
+    end
+  end
+end

--- a/lib/elftools/dynamic/symbols.rb
+++ b/lib/elftools/dynamic/symbols.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'elftools/dynamic/hash_table'
 require 'elftools/exceptions'
 require 'elftools/sections/symbol'
 require 'elftools/structs'
@@ -55,7 +56,7 @@ module ELFTools
       #   elf.dynamic.num_symbols
       #   #=> 9
       def num_symbols
-        @num_symbols ||= [count_from_hash, count_from_gnu_hash, count_from_relocations].compact.max || 0
+        @num_symbols ||= (hash_tables.map(&:num_symbols) + [count_from_relocations]).compact.max || 0
       end
 
       # Iterate all symbols.
@@ -87,45 +88,34 @@ module ELFTools
 
       # Get symbol by its name.
       #
-      # Only the symbols {#symbols} reaches are searched.
+      # The hash tables answer first, which is the lookup the loader itself
+      # performs and takes no scanning. They do not index every symbol, and a
+      # file need not record one at all, so a name they do not lead to is
+      # searched for among the symbols {#symbols} reaches.
       # @param [String] name The name of symbol.
       # @return [ELFTools::Sections::Symbol, nil] The desired symbol.
+      # @example
+      #   elf.dynamic.symbol_by_name('__libc_start_main').type_name
+      #   #=> 'STT_FUNC'
       def symbol_by_name(name)
+        # Lazily, so that a table is only read when the ones before it have
+        # not led anywhere.
+        index = hash_tables.lazy.filter_map { |table| table.index_of(name) { |i| symbol_at(i).name == name } }.first
+        return symbol_at(index) if index
+
         each_symbols.find { |symbol| symbol.name == name }
       end
 
       private
 
-      # How many symbols +DT_HASH+ records, which is exact: a chain of the table
-      # belongs to every symbol, whether the table indexes it or not.
-      # @return [Integer, nil] The number, +nil+ if the tag is absent.
-      def count_from_hash
-        tag = tag_by_type(:hash)
-        return if tag.nil?
-
-        read_struct(Structs::ELF_Hash, offset_of(tag)).nchain.to_i
-      end
-
-      # How far +DT_GNU_HASH+ reaches, i.e. the highest index it indexes plus
-      # one. It only ever indexes the defined symbols a file exports under a
-      # name, and the symbols before +symndx+ are by construction not among
-      # them.
-      # @return [Integer, nil] The number, +nil+ if the tag is absent.
-      def count_from_gnu_hash
-        tag = tag_by_type(:gnu_hash)
-        return if tag.nil?
-
-        base = offset_of(tag)
-        head = read_struct(Structs::ELF_GnuHash, base)
-        buckets = base + head.num_bytes + (head.maskwords.to_i * header.elf_class / 8)
-        last = Array.new(head.nbuckets.to_i) { |i| read_word(buckets + (i * 4)) }.max || 0
-        return head.symndx.to_i if last < head.symndx.to_i
-
-        chain = buckets + (head.nbuckets.to_i * 4)
-        # The chain of a bucket runs on until an entry has its lowest bit set.
-        n = last - head.symndx.to_i
-        n += 1 while read_word(chain + (n * 4)).even?
-        head.symndx.to_i + n + 1
+      # The tables the file records the names it exports in, of whichever kinds
+      # it records.
+      # @return [Array<ELFTools::Dynamic::HashTable>] The tables.
+      def hash_tables
+        @hash_tables ||= { hash: HashTable::SysV, gnu_hash: HashTable::Gnu }.filter_map do |type, klass|
+          tag = tag_by_type(type)
+          klass.new(stream, offset_of(tag), elf_class: header.elf_class, endian:) if tag
+        end
       end
 
       # How far the relocations reach, i.e. the highest index they name plus one.
@@ -134,14 +124,6 @@ module ELFTools
       def count_from_relocations
         highest = relocations.map(&:symbol_index).max
         highest && highest + 1
-      end
-
-      # Reads a word, the unit a hash table lays its entries out in.
-      # @param [Integer] offset The file offset.
-      # @return [Integer] The word.
-      def read_word(offset)
-        stream.pos = offset
-        stream.read(4).unpack1(endian == :big ? 'N' : 'V')
       end
 
       # Get the +DT_SYMTAB+'s +d_val+ offset related to file.

--- a/spec/dynamic_spec.rb
+++ b/spec/dynamic_spec.rb
@@ -9,6 +9,19 @@ describe ELFTools::Dynamic do
     ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', name)))
   end
 
+  # Returns an ELF file whose tag of +type+ has been modified by +block+.
+  # @param [Symbol] type The type of the tag.
+  # @yieldparam [ELFTools::Structs::ELF_Dyn] header The header of the tag.
+  # @yieldreturn [void]
+  # @return [ELFTools::ELFFile]
+  def elf_with_patched_tag(type)
+    data = File.binread(File.join(__dir__, 'files', 'amd64.elf'))
+    header = ELFTools::ELFFile.new(StringIO.new(data)).dynamic.tag_by_type(type).header
+    yield header
+    data[header.offset, header.num_bytes] = header.to_binary_s
+    ELFTools::ELFFile.new(StringIO.new(data))
+  end
+
   # Reads +name+ with its section headers taken away, as a packer or a dumper
   # leaves a file that still runs.
   def elf_without_sections(name)
@@ -158,45 +171,72 @@ describe ELFTools::Dynamic do
 
     it 'reports a table that is not there' do
       # Change the tag type so that DT_SYMTAB no longer exists.
-      file = elf_with_patched_symtab { |header| header.d_tag = ELFTools::Constants::DT_DEBUG }
+      file = elf_with_patched_tag(:symtab) { |header| header.d_tag = ELFTools::Constants::DT_DEBUG }
       expect { file.dynamic.symbol_at(0) }.to raise_error(ELFTools::ELFError, 'DT_SYMTAB not found')
     end
 
     it 'reports a table that is not loaded' do
-      file = elf_with_patched_symtab { |header| header.d_val = 0xdeadbeef000 }
+      file = elf_with_patched_tag(:symtab) { |header| header.d_val = 0xdeadbeef000 }
       expect { file.dynamic.symbol_at(0) }.to \
         raise_error(ELFTools::ELFError, 'Invalid DT_SYMTAB address 0xdeadbeef000')
     end
+  end
 
-    # Returns an ELF file whose DT_SYMTAB tag has been modified by +block+.
-    # @yieldparam [ELFTools::Structs::ELF_Dyn] header The DT_SYMTAB header.
-    # @yieldreturn [void]
-    # @return [ELFTools::ELFFile]
-    def elf_with_patched_symtab
-      data = File.binread(File.join(__dir__, 'files', 'amd64.elf'))
-      header = ELFTools::ELFFile.new(StringIO.new(data)).dynamic.tag_by_type(:symtab).header
-      yield header
-      data[header.offset, header.num_bytes] = header.to_binary_s
-      ELFTools::ELFFile.new(StringIO.new(data))
+  describe 'symbol_by_name' do
+    it 'finds every name a file records' do
+      # Whatever a table leads to and whatever it does not, the answer is the
+      # symbol that bears the name.
+      %w[aarch64.elf amd64.elf arm.elf i386.elf i386.pie.elf i386.so.elf
+         libc.so.6 ppc64.elf riscv64.elf].each do |name|
+        dynamic = elf(name).dynamic
+        names = dynamic.symbols.map(&:name).reject(&:empty?).uniq
+        expect(names).not_to be_empty
+        expect(names.reject { |sym| dynamic.symbol_by_name(sym)&.name == sym }).to be_empty
+      end
+    end
+
+    it 'reads the table of whichever kind a file records' do
+      expect(elf('libc.so.6').dynamic.send(:hash_tables).map(&:class)).to eq \
+        [ELFTools::Dynamic::HashTable::SysV, ELFTools::Dynamic::HashTable::Gnu]
+      # A file built the way the toolchain builds them today records only the
+      # GNU one.
+      expect(elf('amd64.elf').dynamic.send(:hash_tables).map(&:class)).to eq \
+        [ELFTools::Dynamic::HashTable::Gnu]
+    end
+
+    it 'looks a name up instead of searching for it' do
+      dynamic = elf('libc.so.6').dynamic
+      # Searching would mean reading all 2245 symbols to reach this one.
+      expect(dynamic).not_to receive(:each_symbols)
+      expect(dynamic.symbol_by_name('malloc').name).to eq 'malloc'
+    end
+
+    it 'searches for a name no table leads to' do
+      # A table only indexes the symbols a file exports, so the ones an
+      # executable imports are not in it.
+      dynamic = elf('amd64.elf').dynamic
+      expect(dynamic.send(:hash_tables).map { |table| table.index_of('printf') { true } }).to eq [nil]
+      expect(dynamic.symbol_by_name('printf').name).to eq 'printf'
+    end
+
+    it 'searches a file that records no table at all' do
+      # Change the tag type so that DT_GNU_HASH no longer exists.
+      file = elf_with_patched_tag(:gnu_hash) { |header| header.d_tag = ELFTools::Constants::DT_DEBUG }
+      expect(file.dynamic.send(:hash_tables)).to be_empty
+      expect(file.dynamic.symbol_by_name('printf').name).to eq 'printf'
+      expect(file.dynamic.symbol_by_name('no such symbol')).to be nil
+    end
+
+    it 'reports a name that is nowhere' do
+      expect(elf('libc.so.6').dynamic.symbol_by_name('no such symbol')).to be nil
+      expect(elf('amd64.elf').dynamic.symbol_by_name('no such symbol')).to be nil
     end
   end
 
   describe 'broken DT_STRTAB' do
-    # Returns an ELF file whose DT_STRTAB tag has been modified by +block+.
-    # @yieldparam [ELFTools::Structs::ELF_Dyn] header The DT_STRTAB header.
-    # @yieldreturn [void]
-    # @return [ELFTools::ELFFile]
-    def elf_with_patched_strtab
-      data = File.binread(File.join(__dir__, 'files', 'amd64.elf'))
-      header = ELFTools::ELFFile.new(StringIO.new(data)).segment_by_type(:dynamic).tag_by_type(:strtab).header
-      yield header
-      data[header.offset, header.num_bytes] = header.to_binary_s
-      ELFTools::ELFFile.new(StringIO.new(data))
-    end
-
     it 'tag not found' do
       # Change the tag type so that DT_STRTAB no longer exists.
-      elf = elf_with_patched_strtab { |header| header.d_tag = ELFTools::Constants::DT_DEBUG }
+      elf = elf_with_patched_tag(:strtab) { |header| header.d_tag = ELFTools::Constants::DT_DEBUG }
       expect(elf.segment_by_type(:dynamic).tag_by_type(:strtab)).to be nil
       expect { elf.segment_by_type(:dynamic).tag_by_type(:needed).name }.to \
         raise_error(ELFTools::ELFError, 'DT_STRTAB not found')
@@ -205,7 +245,7 @@ describe ELFTools::Dynamic do
     end
 
     it 'address not loadable' do
-      elf = elf_with_patched_strtab { |header| header.d_val = 0xdeadbeef000 }
+      elf = elf_with_patched_tag(:strtab) { |header| header.d_val = 0xdeadbeef000 }
       expect { elf.segment_by_type(:dynamic).tag_by_type(:needed).name }.to \
         raise_error(ELFTools::ELFError, 'Invalid DT_STRTAB address 0xdeadbeef000')
     end


### PR DESCRIPTION
symbol_by_name used to read every symbol until the name turned up. The tables a file records for exactly this are read instead, DT_HASH's and DT_GNU_HASH's, each of which hashes the name and follows the chain its bucket leads to. On libc.so.6 that is 133x to 201x faster than the scan it replaces, since reaching malloc no longer means reading the 2244 symbols that are not it.

Neither table indexes every symbol, though: DT_GNU_HASH only indexes the defined symbols a file exports under a name, which of an executable is next to nothing, so amd64.elf's leads to 1 of its 8 named symbols and ppc64.elf's to none. A file may also record no table at all. A name no table leads to is therefore still searched for, and the answer is the same either way: every one of the 2321 names the twelve loaded files record is found, and a name none of them records is nil.

The tables answer how far they reach as well, which is what the symbol count already asked them, so the counting moves into them too.