### PR TITLE
Read the relocations a dynamic table records once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,9 @@ entries here are collected from those announcements and from the commit history.
 
 ### Changed
 
+- `Dynamic#relocations` reads a table once instead of re-reading it on every call, so the
+  relocations it returns are the same objects each time
+  ([#106](https://github.com/david942j/rbelftools/pull/106))
 - The `bindata` requirement is relaxed to `>= 2, < 4`
   ([#81](https://github.com/david942j/rbelftools/pull/81))
 - `Constants::EM` and the names behind `ELFFile#machine` are generated from binutils

--- a/lib/elftools/dynamic.rb
+++ b/lib/elftools/dynamic.rb
@@ -125,7 +125,7 @@ module ELFTools
     #   elf.dynamic.relocations.map(&:type_name).uniq
     #   #=> ['R_X86_64_GLOB_DAT', 'R_X86_64_JUMP_SLOT']
     def relocations
-      relocation_tables.flat_map { |start, size, rela| read_relocations(start, size, rela) }
+      @relocations ||= relocation_tables.flat_map { |start, size, rela| read_relocations(start, size, rela) }
     end
 
     private

--- a/spec/dynamic_spec.rb
+++ b/spec/dynamic_spec.rb
@@ -97,6 +97,11 @@ describe ELFTools::Dynamic do
       expect(summarize(file.dynamic.relocations)).to eq summarize(from_sections(elf('amd64.elf')))
     end
 
+    it 'reads a table once' do
+      dynamic = elf('libc.so.6').dynamic
+      expect(dynamic.relocations).to be dynamic.relocations
+    end
+
     it 'reports a table that is not loaded' do
       data = File.binread(File.join(__dir__, 'files', 'amd64.elf'))
       tag = ELFTools::ELFFile.new(StringIO.new(data)).dynamic.tag_by_type(:jmprel)


### PR DESCRIPTION
Every call used to re-read the stream and build the relocations again, which #num_symbols pays for as well. They are the same bytes each time, so they are read once, as #tags already are. All 1457 relocations of the files here are unchanged, byte for byte, and the 1287 of libc.so.6 now cost 0.109s once rather than on every call.