### PR TITLE
Skip the spec directory the way SimpleCov asks for

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,5 +8,5 @@ SimpleCov.start do
                                                        SimpleCov::Formatter::JSONFormatter,
                                                        SimpleCov::Formatter::HTMLFormatter
                                                      ])
-  add_filter '/spec/'
+  skip '/spec/'
 end


### PR DESCRIPTION
add_filter now warns that it is deprecated in favour of skip, which takes the same arguments and behaves the same way, on every run of the suite. Coverage is unchanged at 5482 of 5482 lines.