### PR TITLE
Name each iterator after the one thing it yields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,12 @@ entries here are collected from those announcements and from the commit history.
 
 ### Changed
 
+- Every iterator is named in the singular, `ELFFile#each_section` and `#each_segment`,
+  `Dynamic#each_tag`, `Note#each_note`, `Sections::RelocationSection#each_relocation`, and
+  `#each_symbol` of both `Sections::SymTabSection` and `Dynamic`, which is how Ruby names
+  the ones it defines itself and agrees with the one thing each of them yields. The plural
+  name each used to go by is an alias of it, so nothing that calls one has to change
+  ([#108](https://github.com/david942j/rbelftools/pull/108))
 - The `bindata` requirement is relaxed to `>= 2, < 4`
   ([#81](https://github.com/david942j/rbelftools/pull/81))
 - `Constants::EM` and the names behind `ELFFile#machine` are generated from binutils

--- a/lib/elftools/dynamic.rb
+++ b/lib/elftools/dynamic.rb
@@ -28,8 +28,8 @@ module ELFTools
     # @return [Enumerator<ELFTools::Dynamic::Tag>, Array<ELFTools::Dynamic::Tag>]
     #   If block is not given, an enumerator will be returned.
     #   Otherwise, return array of tags.
-    def each_tags(&block)
-      return enum_for(:each_tags) unless block_given?
+    def each_tag(&block)
+      return enum_for(:each_tag) unless block_given?
 
       arr = []
       0.step do |i|
@@ -40,11 +40,14 @@ module ELFTools
       arr
     end
 
+    # The name this used to go by, kept so that it keeps working.
+    alias each_tags each_tag
+
     # Use {#tags} to get all tags.
     # @return [Array<ELFTools::Dynamic::Tag>]
     #   Array of tags.
     def tags
-      @tags ||= each_tags.to_a
+      @tags ||= each_tag.to_a
     end
 
     # Get a tag of specific type.
@@ -73,7 +76,7 @@ module ELFTools
     #   #=> #<ELFTools::Dynamic::Tag:0x0055d3d2d91b28 @header={:d_tag=>3, :d_val=>6295552}>
     def tag_by_type(type)
       type = Util.to_constant(Constants::DT, type)
-      each_tags.find { |tag| tag.header.d_tag == type }
+      each_tag.find { |tag| tag.header.d_tag == type }
     end
 
     # Get tags of specific type.
@@ -85,7 +88,7 @@ module ELFTools
     # @see #tag_by_type
     def tags_by_type(type)
       type = Util.to_constant(Constants::DT, type)
-      each_tags.select { |tag| tag.header.d_tag == type }
+      each_tag.select { |tag| tag.header.d_tag == type }
     end
 
     # Get the +n+-th tag.

--- a/lib/elftools/dynamic/symbols.rb
+++ b/lib/elftools/dynamic/symbols.rb
@@ -68,11 +68,14 @@ module ELFTools
       # @return [Enumerator<ELFTools::Sections::Symbol>, Array<ELFTools::Sections::Symbol>]
       #   If block is not given, an enumerator will be returned.
       #   Otherwise, return array of symbols.
-      def each_symbols(&block)
-        return enum_for(:each_symbols) unless block_given?
+      def each_symbol(&block)
+        return enum_for(:each_symbol) unless block_given?
 
         Array.new(num_symbols) { |i| symbol_at(i).tap(&block) }
       end
+
+      # The name this used to go by, kept so that it keeps working.
+      alias each_symbols each_symbol
 
       # The symbols the tags point at, which is where a file that has been
       # stripped of its sections still records them.
@@ -83,7 +86,7 @@ module ELFTools
       #   elf.dynamic.symbols.map(&:name)
       #   #=> ['', 'puts', '__stack_chk_fail', 'printf', '__libc_start_main']
       def symbols
-        each_symbols.to_a
+        each_symbol.to_a
       end
 
       # Get symbol by its name.
@@ -103,7 +106,7 @@ module ELFTools
         index = hash_tables.lazy.filter_map { |table| table.index_of(name) { |i| symbol_at(i).name == name } }.first
         return symbol_at(index) if index
 
-        each_symbols.find { |symbol| symbol.name == name }
+        each_symbol.find { |symbol| symbol.name == name }
       end
 
       private

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -124,7 +124,7 @@ module ELFTools
     #   elf.section_by_name('no such section')
     #   #=> nil
     def section_by_name(name)
-      each_sections.find { |sec| sec.name == name }
+      each_section.find { |sec| sec.name == name }
     end
 
     # Iterate all sections.
@@ -138,19 +138,22 @@ module ELFTools
     # @return [Enumerator<ELFTools::Sections::Section>, Array<ELFTools::Sections::Section>]
     #   As +Array#each+, if block is not given, a enumerator will be returned,
     #   otherwise, the whole sections will be returned.
-    def each_sections(&block)
-      return enum_for(:each_sections) unless block_given?
+    def each_section(&block)
+      return enum_for(:each_section) unless block_given?
 
       Array.new(num_sections) do |i|
         section_at(i).tap(&block)
       end
     end
 
+    # The name this used to go by, kept so that it keeps working.
+    alias each_sections each_section
+
     # Simply use {#sections} to get all sections.
     # @return [Array<ELFTools::Sections::Section>]
     #   Whole sections.
     def sections
-      each_sections.to_a
+      each_section.to_a
     end
 
     # Acquire the +n+-th section, 0-based.
@@ -181,7 +184,7 @@ module ELFTools
     #   #    #<ELFTools::Sections::RelocationSection:0x00563cd3b89d70>]
     def sections_by_type(type, &)
       type = Util.to_constant(Constants::SHT, type)
-      Util.select_by_type(each_sections, type, &)
+      Util.select_by_type(each_section, type, &)
     end
 
     # Get the string table section.
@@ -211,19 +214,22 @@ module ELFTools
     # @yieldreturn [void]
     # @return [Array<ELFTools::Segments::Segment>]
     #   Whole segments will be returned.
-    def each_segments(&block)
-      return enum_for(:each_segments) unless block_given?
+    def each_segment(&block)
+      return enum_for(:each_segment) unless block_given?
 
       Array.new(num_segments) do |i|
         segment_at(i).tap(&block)
       end
     end
 
+    # The name this used to go by, kept so that it keeps working.
+    alias each_segments each_segment
+
     # Simply use {#segments} to get all segments.
     # @return [Array<ELFTools::Segments::Segment>]
     #   Whole segments.
     def segments
-      each_segments.to_a
+      each_segment.to_a
     end
 
     # Get the first segment with +p_type=type+.
@@ -269,7 +275,7 @@ module ELFTools
     #   #=> nil # no such segment exists
     def segment_by_type(type)
       type = Util.to_constant(Constants::PT, type)
-      each_segments.find { |seg| seg.header.p_type == type }
+      each_segment.find { |seg| seg.header.p_type == type }
     end
 
     # Fetch all segments with specific type.
@@ -284,7 +290,7 @@ module ELFTools
     # @return [Array<ELFTools::Segments::Segment>] The target segments.
     def segments_by_type(type, &)
       type = Util.to_constant(Constants::PT, type)
-      Util.select_by_type(each_segments, type, &)
+      Util.select_by_type(each_segment, type, &)
     end
 
     # Acquire the +n+-th segment, 0-based.

--- a/lib/elftools/note.rb
+++ b/lib/elftools/note.rb
@@ -41,8 +41,8 @@ module ELFTools
     # @return [Enumerator<ELFTools::Note::Note>, Array<ELFTools::Note::Note>]
     #   If block is not given, an enumerator will be returned.
     #   Otherwise, return the array of notes.
-    def each_notes
-      return enum_for(:each_notes) unless block_given?
+    def each_note
+      return enum_for(:each_note) unless block_given?
 
       @notes_offset_map ||= {}
       cur = note_start
@@ -61,11 +61,14 @@ module ELFTools
       notes
     end
 
+    # The name this used to go by, kept so that it keeps working.
+    alias each_notes each_note
+
     # Simply +#notes+ to get all notes.
     # @return [Array<ELFTools::Note::Note>]
     #   Whole notes.
     def notes
-      each_notes.to_a
+      each_note.to_a
     end
 
     private

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -57,19 +57,22 @@ module ELFTools
       # @return [Enumerator<ELFTools::Relocation>, Array<ELFTools::Relocation>]
       #   If block is not given, an enumerator will be returned.
       #   Otherwise, the whole relocations will be returned.
-      def each_relocations(&block)
-        return enum_for(:each_relocations) unless block_given?
+      def each_relocation(&block)
+        return enum_for(:each_relocation) unless block_given?
 
         Array.new(num_relocations) do |i|
           relocation_at(i).tap(&block)
         end
       end
 
+      # The name this used to go by, kept so that it keeps working.
+      alias each_relocations each_relocation
+
       # Simply use {#relocations} to get all relocations.
       # @return [Array<ELFTools::Relocation>]
       #   Whole relocations.
       def relocations
-        each_relocations.to_a
+        each_relocation.to_a
       end
 
       private

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -61,19 +61,22 @@ module ELFTools
       # @return [Enumerator<ELFTools::Sections::Symbol>, Array<ELFTools::Sections::Symbol>]
       #   If block is not given, an enumerator will be returned.
       #   Otherwise return array of symbols.
-      def each_symbols(&block)
-        return enum_for(:each_symbols) unless block_given?
+      def each_symbol(&block)
+        return enum_for(:each_symbol) unless block_given?
 
         Array.new(num_symbols) do |i|
           symbol_at(i).tap(&block)
         end
       end
 
+      # The name this used to go by, kept so that it keeps working.
+      alias each_symbols each_symbol
+
       # Simply use {#symbols} to get all symbols.
       # @return [Array<ELFTools::Sections::Symbol>]
       #   The whole symbols.
       def symbols
-        each_symbols.to_a
+        each_symbol.to_a
       end
 
       # Get symbol by its name.
@@ -81,7 +84,7 @@ module ELFTools
       #   The name of symbol.
       # @return [ELFTools::Sections::Symbol] Desired symbol.
       def symbol_by_name(name)
-        each_symbols.find { |symbol| symbol.name == name }
+        each_symbol.find { |symbol| symbol.name == name }
       end
 
       # Return the symbol string section.

--- a/spec/compatibility_spec.rb
+++ b/spec/compatibility_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'elftools/elf_file'
+
+describe 'the names the iterators used to go by' do
+  # Every iterator, paired with the object that answers it. The plural name
+  # each one used to go by is an alias of the singular it goes by now, so both
+  # have to iterate the same things.
+  def iterators
+    elf = ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', 'amd64.elf')))
+    { elf => %i[section segment],
+      elf.dynamic => %i[tag symbol],
+      elf.section_by_name('.symtab') => %i[symbol],
+      elf.sections_by_type(:rela).first => %i[relocation],
+      elf.section_by_name('.note.ABI-tag') => %i[note] }
+  end
+
+  it 'iterates what the names they go by now do' do
+    iterators.each do |object, names|
+      names.each do |name|
+        singular = object.public_send(:"each_#{name}").to_a
+        expect(singular).not_to be_empty
+        expect(object.public_send(:"each_#{name}s").to_a).to eq singular
+      end
+    end
+  end
+
+  it 'is the very same method under either name' do
+    iterators.each do |object, names|
+      names.each do |name|
+        expect(object.class.instance_method(:"each_#{name}s").original_name).to eq :"each_#{name}"
+      end
+    end
+  end
+end

--- a/spec/dynamic_spec.rb
+++ b/spec/dynamic_spec.rb
@@ -157,10 +157,10 @@ describe ELFTools::Dynamic do
       expect(dynamic.symbol_by_name('no such symbol')).to be nil
     end
 
-    it 'each_symbols' do
+    it 'each_symbol' do
       dynamic = elf('amd64.elf').dynamic
-      expect(dynamic.each_symbols).to be_a Enumerator
-      expect(dynamic.each_symbols.map(&:name)).to eq dynamic.symbols.map(&:name)
+      expect(dynamic.each_symbol).to be_a Enumerator
+      expect(dynamic.each_symbol.map(&:name)).to eq dynamic.symbols.map(&:name)
     end
 
     it 'reads them from a file that has no sections left' do
@@ -207,7 +207,7 @@ describe ELFTools::Dynamic do
     it 'looks a name up instead of searching for it' do
       dynamic = elf('libc.so.6').dynamic
       # Searching would mean reading all 2245 symbols to reach this one.
-      expect(dynamic).not_to receive(:each_symbols)
+      expect(dynamic).not_to receive(:each_symbol)
       expect(dynamic.symbol_by_name('malloc').name).to eq 'malloc'
     end
 


### PR DESCRIPTION
each_symbols yields a symbol, not symbols, and Ruby names every iterator it defines itself in the singular: of the 14 each_* methods Enumerable, String, Array, Hash, Integer, IO, Struct, Range, and Enumerator define, not one is plural, each_cons being short for consecutive rather than an exception.

So each_tag, each_section, each_segment, each_relocation, each_note, and each_symbol of both the sections and the tags. The name each used to go by is an alias of it, so nothing that calls one has to change, and a spec covers both names of all seven. Everything here calls the singular.