### PR TITLE
Name the table of section names after what it holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ entries here are collected from those announcements and from the commit history.
 
 ### Breaking
 
+- `ELFFile#strtab_section` is `ELFFile#section_name_table`. It answers with the section the
+  names of the sections are recorded in, `.shstrtab`, and not with `.strtab`, which records
+  the names of the symbols and which `Sections::SymTabSection#symstr` answers with. The
+  keyword `Sections::Section` takes for it is `section_name_table:` rather than `strtab:`
+  ([#109](https://github.com/david942j/rbelftools/pull/109))
 - Ruby 3.3 or later is required ([#85](https://github.com/david942j/rbelftools/pull/85))
 - Addresses that occupy memory but have no content in file, `.bss` for instance, are
   not converted into a file offset anymore. This affects `ELFFile#offset_from_vma` and

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -187,12 +187,16 @@ module ELFTools
       Util.select_by_type(each_section, type, &)
     end
 
-    # Get the string table section.
+    # The section the names of the sections are recorded in, which the ELF
+    # header names by index.
     #
-    # This section is acquired by using the +e_shstrndx+
-    # in ELF header.
-    # @return [ELFTools::Sections::StrTabSection] The desired section.
-    def strtab_section
+    # It is not the section the names of the symbols are recorded in, which
+    # {ELFTools::Sections::SymTabSection#symstr} answers.
+    # @return [ELFTools::Sections::StrTabSection] The section.
+    # @example
+    #   elf.section_name_table.name
+    #   #=> '.shstrtab'
+    def section_name_table
       section_at(header.e_shstrndx)
     end
 
@@ -407,7 +411,7 @@ module ELFTools
       shdr.read(stream)
       Sections::Section.create(shdr, stream,
                                offset_from_vma: method(:offset_from_vma),
-                               strtab: method(:strtab_section),
+                               section_name_table: method(:section_name_table),
                                section_at: method(:section_at),
                                machine: header.e_machine.to_i)
     end

--- a/lib/elftools/sections/section.rb
+++ b/lib/elftools/sections/section.rb
@@ -13,16 +13,16 @@ module ELFTools
       #   The section header object.
       # @param [#pos=, #read] stream
       #   The streaming object for further dump.
-      # @param [ELFTools::Sections::StrTabSection, Proc] strtab
+      # @param [ELFTools::Sections::StrTabSection, Proc] section_name_table
       #   The string table object. For fetching section names.
       #   If +Proc+ if given, it will call at the first
       #   time access +#name+.
       # @param [Method] offset_from_vma
       #   The method to get offset of file, given virtual memory address.
-      def initialize(header, stream, offset_from_vma: nil, strtab: nil, **_kwargs)
+      def initialize(header, stream, offset_from_vma: nil, section_name_table: nil, **_kwargs)
         @header = header
         @stream = stream
-        @strtab = strtab
+        @section_name_table = section_name_table
         @offset_from_vma = offset_from_vma
       end
 
@@ -36,7 +36,7 @@ module ELFTools
       # Get name of this section.
       # @return [String] The name.
       def name
-        @name ||= @strtab.call.name_at(header.sh_name)
+        @name ||= @section_name_table.call.name_at(header.sh_name)
       end
 
       # Fetch data of this section.

--- a/spec/elf_file_spec.rb
+++ b/spec/elf_file_spec.rb
@@ -39,7 +39,7 @@ describe ELFTools::ELFFile do
         .comment .shstrtab .symtab .strtab
       ]
 
-      expect(@elf.section_by_name('.shstrtab')).to be @elf.strtab_section
+      expect(@elf.section_by_name('.shstrtab')).to be @elf.section_name_table
       expect(@elf.section_by_name('no such section')).to be nil
     end
 


### PR DESCRIPTION
strtab_section returns the section e_shstrndx names, which records the names of the sections, .shstrtab. The section called .strtab records the names of the symbols, and is what SymTabSection#symstr returns. Asking for the one by the name of the other got no error, only the wrong table, so it is section_name_table now, and the keyword a section takes for it is section_name_table: too.