### PR TITLE
Name a relocation's two values after what they mean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ entries here are collected from those announcements and from the commit history.
 
 ### Breaking
 
+- `Relocation#r_info_sym` and `#r_info_type` are gone. `#symbol_index` and `#type`, which
+  used to be aliases of them, are the names now. They name what the two values mean rather
+  than the field they are read out of, which since [#97](https://github.com/david942j/rbelftools/pull/97) is not even how every file records
+  them: the 64-bit MIPS ABI packs three types and a second symbol index into `r_info`
+  instead of halving it ([#110](https://github.com/david942j/rbelftools/pull/110))
 - Ruby 3.3 or later is required ([#85](https://github.com/david942j/rbelftools/pull/85))
 - Addresses that occupy memory but have no content in file, `.bss` for instance, are
   not converted into a file offset anymore. This affects `ELFFile#offset_from_vma` and

--- a/lib/elftools/relocation.rb
+++ b/lib/elftools/relocation.rb
@@ -23,21 +23,19 @@ module ELFTools
       @machine = machine
     end
 
-    # +r_info+ contains sym and type, use two methods
-    # to access them easier.
+    # Which symbol this relocation is against, as an index into the symbol
+    # table.
     # @return [Integer] The symbol index.
-    def r_info_sym
+    def symbol_index
       sym_and_type.first
     end
-    alias symbol_index r_info_sym
 
-    # +r_info+ contains sym and type, use two methods
-    # to access them easier.
+    # What this relocation does, which only means something together with the
+    # machine of the file. {#type_name} names it.
     # @return [Integer] The relocation type.
-    def r_info_type
+    def type
       sym_and_type.last
     end
-    alias type r_info_type
 
     # The name of {#type}.
     #

--- a/spec/full_test/relro_spec.rb
+++ b/spec/full_test/relro_spec.rb
@@ -30,34 +30,34 @@ describe 'Full test for relro types' do
   end
 
   it 'r_info type' do
-    expect(@nrelro.section_by_name('.rela.plt').relocations.map(&:r_info_type).uniq).to eq [7]
-    expect(@partial.section_by_name('.rela.plt').relocations.map(&:r_info_type).uniq).to eq [7]
+    expect(@nrelro.section_by_name('.rela.plt').relocations.map(&:type).uniq).to eq [7]
+    expect(@partial.section_by_name('.rela.plt').relocations.map(&:type).uniq).to eq [7]
 
-    expect(@partial.section_by_name('.rela.dyn').relocations.map(&:r_info_type)).to eq [6, 5]
-    expect(@frelro.section_by_name('.rela.dyn').relocations.map(&:r_info_type)).to eq [6, 6, 6, 6, 6, 6, 6, 5]
+    expect(@partial.section_by_name('.rela.dyn').relocations.map(&:type)).to eq [6, 5]
+    expect(@frelro.section_by_name('.rela.dyn').relocations.map(&:type)).to eq [6, 6, 6, 6, 6, 6, 6, 5]
   end
 
   it 'plt symbols' do
     section = @partial.section_by_name('.rela.plt')
     symtab = @partial.section_at(section.header.sh_link)
-    symbols = section.relocations.map(&:r_info_sym).map { |c| symtab.symbol_at(c).name }
+    symbols = section.relocations.map(&:symbol_index).map { |c| symtab.symbol_at(c).name }
     expect(symbols).to eq %w[puts __stack_chk_fail printf __libc_start_main fgets scanf]
 
     section = @nrelro.section_by_name('.rela.plt')
     symtab = @nrelro.section_at(section.header.sh_link)
-    nrelro_symbols = section.relocations.map(&:r_info_sym).map { |c| symtab.symbol_at(c).name }
+    nrelro_symbols = section.relocations.map(&:symbol_index).map { |c| symtab.symbol_at(c).name }
     expect(nrelro_symbols).to eq symbols
   end
 
   it 'dyn symbols' do
     section = @partial.section_by_name('.rela.dyn')
     symtab = @partial.section_at(section.header.sh_link)
-    symbols = section.relocations.map(&:r_info_sym).map { |c| symtab.symbol_at(c).name }
+    symbols = section.relocations.map(&:symbol_index).map { |c| symtab.symbol_at(c).name }
     expect(symbols).to eq %w[__gmon_start__ stdin]
 
     section = @frelro.section_by_name('.rela.dyn')
     symtab = @frelro.section_at(section.header.sh_link)
-    frelro_symbols = section.relocations.map(&:r_info_sym).map { |c| symtab.symbol_at(c).name }
+    frelro_symbols = section.relocations.map(&:symbol_index).map { |c| symtab.symbol_at(c).name }
     expect(frelro_symbols).to eq %w[puts __stack_chk_fail printf __libc_start_main fgets __gmon_start__ scanf stdin]
   end
 end


### PR DESCRIPTION
r_info_sym and r_info_type were the methods and symbol_index and type the aliases of them, which is backwards: the names that meant something were the ones kept as spares. The mechanism the other two name stopped being true in #97 besides, where the 64-bit MIPS ABI turned out to pack three types and a second symbol index into r_info rather than halving it, so there is no r_info sym half of such a file to speak of.