### PR TITLE
Patch a field however deeply it is nested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ Releases up to 1.3.1 were announced on the
 [releases page](https://github.com/david942j/rbelftools/releases) only, their
 entries here are collected from those announcements and from the commit history.
 
+## Unreleased
+
+### Fixed
+
+- Assigning to a field of a structure a header records, `e_ident` and each of the seven
+  fields it holds, used to be dropped without a word. The value read back as assigned and
+  `save` wrote the file out unchanged, because only the fields of the outermost structure
+  were watched ([#111](https://github.com/david942j/rbelftools/pull/111))
+- Patching any field of a big endian file used to write the bytes of that field the wrong
+  way round, because the packing was asked of the base structure class, which is ordered
+  little endian whatever the file is
+  ([#111](https://github.com/david942j/rbelftools/pull/111))
+
+### Changed
+
+- `Structs::ELFStruct#patches` answers with the difference between the bytes a structure
+  was read from and the bytes it holds now, as the runs of bytes that differ, instead of a
+  log of the assignments made to it. Every field is therefore patchable however deeply it
+  is nested, and a field assigned the value it already held leaves nothing behind.
+  `Structs::ELFStruct.pack` is no longer how a patch is made, and is deprecated
+  ([#111](https://github.com/david942j/rbelftools/pull/111))
+
 ## 2.0.0 - 2026-08-24
 
 ### Breaking

--- a/lib/elftools/structs.rb
+++ b/lib/elftools/structs.rb
@@ -18,14 +18,57 @@ module ELFTools
       attr_accessor :elf_class # @return [Integer] 32 or 64.
       attr_accessor :offset # @return [Integer] The file offset of this header.
 
-      # Records which fields have been patched.
-      # @return [Hash{Integer => Integer}] Patches.
+      # Reads the structure, remembering the bytes it was read from.
+      # @param [#pos=, #read] io The streaming object.
+      # @return [ELFTools::Structs::ELFStruct] Itself.
+      def read(io)
+        super.tap { @source = to_binary_s }
+      end
+
+      # Which bytes of this structure have been changed since it was read.
+      #
+      # Every field answers alike, however deeply it is nested, because what is
+      # compared is the bytes the structure occupies rather than the
+      # assignments that were made to it. A field assigned the value it
+      # already held leaves nothing behind.
+      # @return [Hash{Integer => String}]
+      #   Where each run of changed bytes starts, as an offset into the
+      #   structure, and the bytes it is to be replaced with.
+      # @example
+      #   header.e_ident.ei_abiversion = 41
+      #   header.patches
+      #   #=> { 8 => "\x29" }
       def patches
-        @patches ||= {}
+        return {} if @source.nil?
+
+        changed_runs(@source, to_binary_s)
       end
 
       # BinData hash(Snapshot) that behaves like HashWithIndifferentAccess
       alias to_h snapshot
+
+      private
+
+      # Where two strings of bytes differ, as the runs of bytes that differ.
+      #
+      # Only as far as +before+ reaches, so that a patch never covers more of
+      # the file than the structure it came from.
+      # @param [String] before The bytes as they were.
+      # @param [String] after The bytes as they are.
+      # @return [Hash{Integer => String}] Where each run starts, and its bytes.
+      def changed_runs(before, after)
+        runs = {}
+        start = nil
+        (0..before.bytesize).each do |i|
+          if i < before.bytesize && before.getbyte(i) != after.getbyte(i)
+            start ||= i
+          elsif start
+            runs[start] = after.byteslice(start, i - start)
+            start = nil
+          end
+        end
+        runs
+      end
 
       class << self
         # Hooks the constructor.
@@ -41,19 +84,7 @@ module ELFTools
         def new(*args)
           kwargs = args.last.is_a?(Hash) ? args.last : {}
           offset = kwargs.delete(:offset)
-          super.tap do |obj|
-            obj.offset = offset
-            obj.field_names.each do |f|
-              m = :"#{f}="
-              old_method = obj.singleton_method(m)
-              obj.singleton_class.send(:undef_method, m)
-              obj.define_singleton_method(m) do |val|
-                org = obj.send(f)
-                obj.patches[org.abs_offset] = ELFStruct.pack(val, org.num_bytes)
-                old_method.call(val)
-              end
-            end
-          end
+          super.tap { |obj| obj.offset = offset }
         end
 
         # Gets the endianness of current class.
@@ -63,6 +94,10 @@ module ELFTools
         end
 
         # Packs an integer to string.
+        #
+        # @deprecated
+        #   Nothing here packs a patch by hand anymore, see {ELFStruct#patches}.
+        #   This is kept for anyone who called it and goes in the next major.
         # @param [Integer] val
         # @param [Integer] bytes
         # @return [String]

--- a/spec/elf_file_spec.rb
+++ b/spec/elf_file_spec.rb
@@ -227,6 +227,32 @@ describe ELFTools::ELFFile do
       expect(patched_elf.section_by_name('.text').header.sh_addr).to eq 0xdeadbeef
       out.close!
     end
+
+    it 'patches a field of a structure a header records' do
+      out = Tempfile.new('elftools')
+      out.close
+      elf = described_class.new(File.open(@filepath))
+      elf.header.e_ident.ei_abiversion = 41
+      elf.save(out.path)
+      out.reopen(out.path, 'rb')
+      expect(described_class.new(out).header.e_ident.ei_abiversion).to eq 41
+      out.close!
+    end
+
+    it 'patches a file whichever way it is ordered' do
+      # A field is written the way the file records it, which only a big
+      # endian file disagrees with.
+      %w[amd64.elf ppc64.elf].each do |name|
+        out = Tempfile.new('elftools')
+        out.close
+        elf = described_class.new(File.open(File.join(__dir__, 'files', name)))
+        elf.header.e_machine = ELFTools::Constants::EM_ARM
+        elf.save(out.path)
+        out.reopen(out.path, 'rb')
+        expect(described_class.new(out).machine).to eq 'ARM'
+        out.close!
+      end
+    end
   end
 
   describe 'accessibility' do

--- a/spec/structs_spec.rb
+++ b/spec/structs_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'elftools/elf_file'
+
+describe ELFTools::Structs::ELFStruct do
+  def header(name = 'amd64.elf')
+    ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', name))).header
+  end
+
+  describe 'patches' do
+    it 'reports nothing while nothing has changed' do
+      expect(header.patches).to eq({})
+    end
+
+    it 'reports a field however deeply it is nested' do
+      hdr = header
+      # EI_ABIVERSION is the ninth byte of what e_ident records, and e_ident is
+      # a structure of its own, which nothing used to be able to patch.
+      hdr.e_ident.ei_abiversion = 41
+      expect(hdr.patches).to eq({ 8 => 41.chr })
+    end
+
+    it 'reports nothing for a field assigned what it already held' do
+      hdr = header
+      hdr.e_machine = ELFTools::Constants::EM_ARM
+      hdr.e_machine = ELFTools::Constants::EM_X86_64
+      expect(hdr.patches).to eq({})
+    end
+
+    it 'reports each run of changed bytes on its own' do
+      hdr = header
+      hdr.e_ident.ei_osabi = 3
+      hdr.e_machine = ELFTools::Constants::EM_ARM
+      expect(hdr.patches).to eq({ 7 => 3.chr, 18 => 40.chr })
+    end
+
+    it 'orders the bytes the way the file it was read from does' do
+      # The same assignment, of a number whose halves differ, reaches a
+      # different byte of the field in a file ordered the other way.
+      expect(header('amd64.elf').tap { |hdr| hdr.e_machine = 40 }.patches).to eq({ 18 => 40.chr })
+      expect(header('ppc64.elf').tap { |hdr| hdr.e_machine = 40 }.patches).to eq({ 19 => 40.chr })
+    end
+
+    it 'reports nothing for a structure that was never read' do
+      expect(ELFTools::Structs::ELF_Dyn.new(endian: :little).patches).to eq({})
+    end
+  end
+
+  describe '.pack' do
+    it 'packs an integer the way the class it is asked of is ordered' do
+      expect(ELFTools::Structs::ELF_DynLe.pack(0x0102, 2)).to eq "\x02\x01".b
+      expect(ELFTools::Structs::ELF_DynBe.pack(0x0102, 2)).to eq "\x01\x02".b
+      expect { ELFTools::Structs::ELF_DynLe.pack('x', 2) }
+        .to raise_error(ArgumentError, 'Not supported assign type String')
+    end
+  end
+end


### PR DESCRIPTION
Only the fields of the outermost structure were watched, so assigning to e_ident, the one structure a header records, was dropped without a word: the value read back as assigned, and save wrote the file out unchanged. A fix that reached one level down would only move the trap, so nothing watches assignments now. A structure remembers the bytes it was read from, and its patches are the runs of bytes that differ from them. Every field answers alike whatever holds it, and a field assigned the value it already held leaves nothing behind.

That also settles an order the old way got wrong. Packing was asked of ELFStruct, whose name ends in neither le nor be and which therefore reads as little endian whatever the file is, so patching a field of ppc64.elf wrote its bytes the wrong way round. to_binary_s asks the structure that holds the field, so a big endian file is written as one.

The bytes are unchanged for what already worked: the amd64.elf header, section, and segment fields of the patch spec save byte for byte identically before and after. A patch is also never coarser than before, since a run only covers the bytes that differ. 24106 headers of the files here re-serialize to exactly what they were read from, which is what the comparison rests on.