### PR TITLE
Assign what a symbol and a relocation mean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ entries here are collected from those announcements and from the commit history.
 
 ## Unreleased
 
+### Added
+
+- `Sections::Symbol#type=`, `#bind=`, and `#visibility=`, and `Relocation#type=` and
+  `#symbol_index=`, which assign what a value means rather than the bits recording it. Each
+  leaves the rest of the byte or field it shares alone, the 64-bit MIPS ABI layout and the
+  machine's own half of `st_other` included, and reports a value too large for its bits
+  instead of writing it over its neighbours
+  ([#112](https://github.com/david942j/rbelftools/pull/112))
+- `Util.fits!`, which is what reports it
+  ([#112](https://github.com/david942j/rbelftools/pull/112))
+
 ### Fixed
 
 - Assigning to a field of a structure a header records, `e_ident` and each of the seven

--- a/README.md
+++ b/README.md
@@ -256,6 +256,26 @@ interp_segment.interp_name
 # save the patched ELF
 elf.save('elf.patched')
 
+Values that share a byte with others, which a symbol and a relocation both record, are
+assigned as what they mean rather than as the bits holding them. A value too large for
+its bits is reported instead of being written over its neighbours.
+```ruby
+elf = ELFTools::ELFFile.new(File.open('spec/files/amd64.elf'))
+symbol = elf.section_by_name('.symtab').symbol_by_name('main')
+symbol.type = ELFTools::Constants::STT_OBJECT
+symbol.bind = ELFTools::Constants::STB_WEAK
+[symbol.type_name, symbol.bind_name]
+#=> ["STT_OBJECT", "STB_WEAK"]
+symbol.bind = 16
+#=> ArgumentError: Symbol binding must be in 0..15, got 16
+
+relocation = elf.dynamic.relocations.first
+relocation.symbol_index = 3
+relocation.type = ELFTools::Constants::R::X86_64::R_X86_64_JUMP_SLOT
+[relocation.symbol_index, relocation.type_name]
+#=> [3, "R_X86_64_JUMP_SLOT"]
+```
+
 # in bash
 # $ file elf.patched
 # elf.patched: ELF 64-bit LSB executable, ARM, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86, for GNU...

--- a/lib/elftools/relocation.rb
+++ b/lib/elftools/relocation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'elftools/constants'
+require 'elftools/util'
 
 module ELFTools
   # A relocation entry.
@@ -37,6 +38,24 @@ module ELFTools
       sym_and_type.last
     end
 
+    # Sets which symbol this relocation is against.
+    # @param [Integer] index The symbol index.
+    # @raise [ArgumentError] If the bits recording it cannot hold it.
+    # @example
+    #   relocation.symbol_index = 3
+    def symbol_index=(index)
+      header.r_info = info_of(Util.fits!(index, index_bits, 'Symbol index'), type)
+    end
+
+    # Sets what this relocation does.
+    # @param [Integer] type The relocation type.
+    # @raise [ArgumentError] If the bits recording it cannot hold it.
+    # @example
+    #   relocation.type = ELFTools::Constants::R::X86_64::R_X86_64_JUMP_SLOT
+    def type=(type)
+      header.r_info = info_of(symbol_index, Util.fits!(type, type_bits, 'Relocation type'))
+    end
+
     # The name of {#type}.
     #
     # Every architecture numbers relocation types on its own, so the name is
@@ -50,6 +69,37 @@ module ELFTools
     end
 
     private
+
+    # The +r_info+ recording a symbol index and a type, laid out the way this
+    # file lays it out. The inverse of {#sym_and_type}.
+    # @return [Integer] The +r_info+.
+    def info_of(index, type)
+      return mips64_info_of(index, type) if mips64?
+
+      (index << mask_bit) | type
+    end
+
+    # The +r_info+ as the 64-bit MIPS ABI records it, leaving the bytes the
+    # ABI keeps for itself as they were.
+    # @return [Integer] The +r_info+.
+    def mips64_info_of(index, type)
+      info = header.r_info.to_i
+      return (index << 32) | (info & 0xffff_ff00) | type if header.class.self_endian == :big
+
+      (info & 0x00ff_ffff_0000_0000) | (type << 56) | index
+    end
+
+    # How many bits record a symbol index.
+    # @return [Integer] The number.
+    def index_bits
+      mips64? ? 32 : (header.elf_class - mask_bit)
+    end
+
+    # How many bits record a relocation type.
+    # @return [Integer] The number.
+    def type_bits
+      mips64? ? 8 : mask_bit
+    end
 
     # What +r_info+ records, i.e. a symbol index and a relocation type. Most
     # machines split the field in half between the two, one lays it out its

--- a/lib/elftools/sections/symbol.rb
+++ b/lib/elftools/sections/symbol.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'elftools/constants'
+require 'elftools/util'
 
 module ELFTools
   module Sections
@@ -43,6 +44,15 @@ module ELFTools
         header.st_info & 0xf
       end
 
+      # Sets what kind of entity this symbol refers to.
+      # @param [Integer] type The type.
+      # @raise [ArgumentError] If the four bits recording it cannot hold it.
+      # @example
+      #   symbol.type = ELFTools::Constants::STT_FUNC
+      def type=(type)
+        header.st_info = (bind << 4) | Util.fits!(type, 4, 'Symbol type')
+      end
+
       # The name of {#type}.
       #
       # A machine names types of its own, so the name is only known when the
@@ -66,6 +76,15 @@ module ELFTools
         header.st_info >> 4
       end
 
+      # Sets how this symbol is linked against others with the same name.
+      # @param [Integer] bind The binding.
+      # @raise [ArgumentError] If the four bits recording it cannot hold it.
+      # @example
+      #   symbol.bind = ELFTools::Constants::STB_WEAK
+      def bind=(bind)
+        header.st_info = (Util.fits!(bind, 4, 'Symbol binding') << 4) | type
+      end
+
       # The name of {#bind}.
       # @return [String] The name.
       # @example
@@ -85,6 +104,19 @@ module ELFTools
       #   #=> true
       def visibility
         header.st_other & 0x3
+      end
+
+      # Sets how this symbol is accessed once it becomes part of an executable
+      # or shared object.
+      #
+      # The rest of +st_other+ is left alone, which some machines record their
+      # own thing in.
+      # @param [Integer] visibility The visibility.
+      # @raise [ArgumentError] If the two bits recording it cannot hold it.
+      # @example
+      #   symbol.visibility = ELFTools::Constants::STV_HIDDEN
+      def visibility=(visibility)
+        header.st_other = (header.st_other.to_i & 0xfc) | Util.fits!(visibility, 2, 'Symbol visibility')
       end
 
       # The name of {#visibility}.

--- a/lib/elftools/util.rb
+++ b/lib/elftools/util.rb
@@ -23,6 +23,26 @@ module ELFTools
         (num + n) & ~(n - 1)
       end
 
+      # Checks a value is one the bits recording it can hold.
+      #
+      # Several of the values a file records share a byte with others, so a
+      # value too large for its bits would be written over its neighbours
+      # instead of being rejected.
+      # @param [Integer] value The value.
+      # @param [Integer] bits How many bits record it.
+      # @param [String] name What the value is, for the error to name.
+      # @return [Integer] The value.
+      # @raise [ArgumentError] If the bits cannot hold it.
+      # @example
+      #   Util.fits!(16, 4, 'Symbol binding')
+      #   #=> ArgumentError: Symbol binding must be in 0..15, got 16
+      def fits!(value, bits, name)
+        highest = (1 << bits) - 1
+        return value if value.is_a?(Integer) && value.between?(0, highest)
+
+        raise ArgumentError, format('%s must be in 0..%d, got %p', name, highest, value)
+      end
+
       # Fetch the correct value from module +mod+.
       #
       # See {ELFTools::ELFFile#segment_by_type} for how to

--- a/spec/relocation_spec.rb
+++ b/spec/relocation_spec.rb
@@ -20,4 +20,46 @@ describe ELFTools::Relocation do
     expect(addends).to all(be_an(Integer))
     expect(addends).to include(be_positive)
   end
+
+  # Writing back what was read changes nothing, whatever the layout, which is
+  # what says the two halves are being put back where they came from.
+  it 'writes each half back where it was read from' do
+    %w[i386.elf amd64.elf aarch64.elf mips64.o mips64el.o].each do |name|
+      rels = relocations(name)
+      expect(rels).not_to be_empty
+      rels.each do |rel|
+        before = rel.header.r_info.to_i
+        wanted = [rel.symbol_index, rel.type]
+        rel.symbol_index = wanted.first
+        rel.type = wanted.last
+        expect(rel.header.r_info.to_i).to eq before
+        expect([rel.symbol_index, rel.type]).to eq wanted
+      end
+    end
+  end
+
+  it 'leaves the bytes the 64-bit MIPS ABI keeps for itself alone' do
+    # 0x0518 of each is the ABI's, and the two files record the very same
+    # relocation the two ways round.
+    big = relocations('mips64.o').first
+    big.symbol_index = 9
+    big.type = 5
+    expect(big.header.r_info.to_i).to eq 0x0000_0009_0005_1805
+
+    little = relocations('mips64el.o').first
+    little.symbol_index = 9
+    little.type = 5
+    expect(little.header.r_info.to_i).to eq 0x0518_0500_0000_0009
+  end
+
+  it 'reports a value the bits recording it cannot hold' do
+    # A 32-bit file leaves a type one byte and a symbol index the other three.
+    rel = relocations('i386.elf').first
+    expect { rel.type = 256 }.to raise_error(ArgumentError, 'Relocation type must be in 0..255, got 256')
+    expect { rel.symbol_index = 1 << 24 }
+      .to raise_error(ArgumentError, 'Symbol index must be in 0..16777215, got 16777216')
+    # A 64-bit one halves it instead.
+    expect { relocations('amd64.elf').first.type = 1 << 32 }
+      .to raise_error(ArgumentError, 'Relocation type must be in 0..4294967295, got 4294967296')
+  end
 end

--- a/spec/symbol_spec.rb
+++ b/spec/symbol_spec.rb
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
 
 require 'elftools/constants'
+require 'tempfile'
+
 require 'elftools/elf_file'
 
 describe ELFTools::Sections::Symbol do
   before(:all) do
     filepath = File.join(__dir__, 'files', 'amd64.elf')
     @symtab = ELFTools::ELFFile.new(File.open(filepath)).section_by_name('.symtab')
+  end
+
+  def own_symtab(name = 'amd64.elf')
+    ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', name))).section_by_name('.symtab')
   end
 
   it 'type' do
@@ -55,5 +61,53 @@ describe ELFTools::Sections::Symbol do
     expect(main.type).to be ELFTools::Constants::STT_FUNC
     expect(main.bind).to be ELFTools::Constants::STB_GLOBAL
     expect(main.visibility).to be ELFTools::Constants::STV_DEFAULT
+  end
+  # Writing back what was read changes neither the byte a type and a binding
+  # share nor the one a visibility shares with whatever else a machine puts
+  # there.
+  it 'writes each value back where it was read from' do
+    symtab = own_symtab
+    expect(symtab.symbols).not_to be_empty
+    symtab.symbols.each do |sym|
+      info = sym.header.st_info.to_i
+      other = sym.header.st_other.to_i
+      wanted = [sym.type, sym.bind, sym.visibility]
+      sym.type = wanted[0]
+      sym.bind = wanted[1]
+      sym.visibility = wanted[2]
+      expect([sym.header.st_info.to_i, sym.header.st_other.to_i]).to eq [info, other]
+      expect([sym.type, sym.bind, sym.visibility]).to eq wanted
+    end
+  end
+
+  it 'leaves what a visibility shares its byte with alone' do
+    sym = own_symtab.symbol_by_name('main')
+    sym.header.st_other = 0xfd # something of a machine's own, and STV_INTERNAL
+    sym.visibility = ELFTools::Constants::STV_HIDDEN
+    expect(sym.header.st_other.to_i).to eq 0xfe
+    expect(sym.visibility).to be ELFTools::Constants::STV_HIDDEN
+  end
+
+  it 'reports a value the bits recording it cannot hold' do
+    sym = own_symtab.symbol_by_name('main')
+    expect { sym.type = 16 }.to raise_error(ArgumentError, 'Symbol type must be in 0..15, got 16')
+    expect { sym.bind = 16 }.to raise_error(ArgumentError, 'Symbol binding must be in 0..15, got 16')
+    expect { sym.visibility = 4 }.to raise_error(ArgumentError, 'Symbol visibility must be in 0..3, got 4')
+  end
+
+  it 'survives being written out' do
+    out = Tempfile.new('elftools')
+    out.close
+    elf = ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', 'amd64.elf')))
+    sym = elf.section_by_name('.symtab').symbol_by_name('main')
+    sym.type = ELFTools::Constants::STT_OBJECT
+    sym.bind = ELFTools::Constants::STB_WEAK
+    sym.visibility = ELFTools::Constants::STV_HIDDEN
+    elf.save(out.path)
+    out.reopen(out.path, 'rb')
+    saved = ELFTools::ELFFile.new(out).section_by_name('.symtab').symbol_by_name('main')
+    expect([saved.type_name, saved.bind_name, saved.visibility_name])
+      .to eq %w[STT_OBJECT STB_WEAK STV_HIDDEN]
+    out.close!
   end
 end

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -13,4 +13,15 @@ describe ELFTools::Util do
     expect(ELFTools::Util.align(7, 1)).to be 8
     expect(ELFTools::Util.align(7, 2)).to be 8
   end
+
+  it 'fits!' do
+    expect(ELFTools::Util.fits!(15, 4, 'Thing')).to be 15
+    expect(ELFTools::Util.fits!(0, 1, 'Thing')).to be 0
+    expect { ELFTools::Util.fits!(16, 4, 'Thing') }
+      .to raise_error(ArgumentError, 'Thing must be in 0..15, got 16')
+    expect { ELFTools::Util.fits!(-1, 4, 'Thing') }
+      .to raise_error(ArgumentError, 'Thing must be in 0..15, got -1')
+    expect { ELFTools::Util.fits!(nil, 4, 'Thing') }
+      .to raise_error(ArgumentError, 'Thing must be in 0..15, got nil')
+  end
 end


### PR DESCRIPTION
Reading a symbol's type, binding, and visibility, and a relocation's type and symbol index, has been possible since #89 and #93. Writing them was not, and doing it by hand means knowing which bits of a shared byte are whose, which is the part worth not leaving to the caller.

Each setter leaves everything it shares with alone. A visibility keeps the six bits of st_other some machines record their own thing in, and a relocation is written the way the file lays r_info out, so the 64-bit MIPS ABI keeps the three bytes it reserves rather than having them flattened by a halving that does not apply to it.

A value too large for the bits recording it is reported, by Util.fits!, rather than written over its neighbours: a binding of 16 would otherwise land in the type beside it. The bits are counted per file, so a type is one byte of a 32-bit file and four of a 64-bit one.

Writing back what was read leaves the bytes exactly as they were, for all 1528 relocations and 3155 symbols of the files here, which is what says each value goes back where it came from.