### PR TITLE
Read the version a symbol binds to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ entries here are collected from those announcements and from the commit history.
 
 ## Unreleased
 
+### Added
+
+- `Sections::Symbol#version` and `#version_hidden?`, the version a symbol binds to, which
+  tells `memcpy@GLIBC_2.14` from the `memcpy@GLIBC_2.2.5` of the same name. `#name` is
+  left as the file records it, without the version appended
+  ([#114](https://github.com/david942j/rbelftools/pull/114))
+- `Dynamic#version_requirements` and `#version_definitions`, the versions a file needs of
+  the files it is loaded with and the versions it defines for what it exports, which
+  answer what a file needs without walking its symbols. Both are read from the tags, so a
+  file stripped of its sections still records them
+  ([#114](https://github.com/david942j/rbelftools/pull/114))
+- `Constants::VER_FLG` and `VER_NDX`, and the `Structs::ELF_Verneed`, `ELF_Vernaux`,
+  `ELF_Verdef`, and `ELF_Verdaux` structures behind them
+  ([#114](https://github.com/david942j/rbelftools/pull/114))
+
 ### Fixed
 
 - `Dynamic#relocations` used to pass over the relocations a file packs into a bitmap, the

--- a/README.md
+++ b/README.md
@@ -139,6 +139,27 @@ dynamic.relocations.map { |rel| dynamic.symbol_at(rel.symbol_index).name }.first
 #=> ["__gmon_start__", "stdin", "puts"]
 ```
 
+A symbol of a file that is loaded binds to a version of the name, which is how one file
+offers `memcpy` twice and each caller keeps the one it was built against. The name is left
+as the file records it.
+```ruby
+dynamic.symbol_by_name('printf').version
+#=> "GLIBC_2.2.5"
+dynamic.symbol_by_name('__stack_chk_fail').version
+#=> "GLIBC_2.4"
+
+# What the file needs, without walking a symbol at all.
+dynamic.version_requirements.map { |need| [need.file, need.versions.map(&:name)] }
+#=> [["libc.so.6", ["GLIBC_2.4", "GLIBC_2.2.5"]]]
+
+# What a library defines, the first naming the library rather than a version of it.
+libc = ELFTools::ELFFile.new(File.open('spec/files/libc.so.6'))
+libc.dynamic.version_definitions.map(&:name).first(3)
+#=> ["libc.so.6", "GLIBC_2.2.5", "GLIBC_2.2.6"]
+libc.dynamic.version_definitions[2].parents
+#=> ["GLIBC_2.2.5"]
+```
+
 Nothing a file is loaded by records how large its symbol table is, because the loader
 looks a name up through a hash table and jumps straight to an index rather than ever
 enumerating it. `num_symbols` is therefore how far the hash table and the relocations

--- a/lib/elftools/constants.rb
+++ b/lib/elftools/constants.rb
@@ -288,6 +288,23 @@ module ELFTools
     end
     include EM
 
+    # Flags of a version, recorded in the +vd_flags+ of a definition and the
+    # +vna_flags+ of a requirement.
+    module VER_FLG
+      VER_FLG_BASE = 0x1 # The version the file itself is, rather than one of the versions it defines
+      VER_FLG_WEAK = 0x2 # A version no symbol is bound to
+      VER_FLG_INFO = 0x4 # A version recorded for information rather than to be matched
+    end
+    include VER_FLG
+
+    # The indices a symbol names a version with that name no version.
+    module VER_NDX
+      VER_NDX_LOCAL = 0 # A symbol of the file itself, which nothing outside it binds to
+      VER_NDX_GLOBAL = 1 # A symbol of no version at all
+      VER_NDX_HIDDEN = 0x8000 # Not an index but a bit of one, marking a version that is not the default
+    end
+    include VER_NDX
+
     # Relocation types, see +elftools/constants/relocation+ for the constants.
     module R
       # Return the name of a relocation type.

--- a/lib/elftools/dynamic.rb
+++ b/lib/elftools/dynamic.rb
@@ -3,6 +3,7 @@
 require 'elftools/constants'
 require 'elftools/dynamic/string_table'
 require 'elftools/dynamic/symbols'
+require 'elftools/dynamic/versions'
 require 'elftools/dynamic/tag'
 require 'elftools/exceptions'
 require 'elftools/relative_relocations'
@@ -18,6 +19,7 @@ module ELFTools
   #   attributes exist.
   module Dynamic
     include Symbols
+    include Versions
 
     # Iterate all tags.
     #

--- a/lib/elftools/dynamic/symbols.rb
+++ b/lib/elftools/dynamic/symbols.rb
@@ -34,7 +34,8 @@ module ELFTools
           # An entry takes what its structure takes, which is also what
           # DT_SYMENT records and what a file has no way of disagreeing with.
           sym = read_struct(klass, sym_offset + (n * struct(klass).num_bytes))
-          Sections::Symbol.new(sym, stream, symstr: method(:string_table), machine: @machine)
+          Sections::Symbol.new(sym, stream, symstr: method(:string_table), machine: @machine,
+                                            version: -> { version_at(n) })
         end
       end
 

--- a/lib/elftools/dynamic/versions.rb
+++ b/lib/elftools/dynamic/versions.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require 'elftools/constants'
+require 'elftools/structs'
+
+module ELFTools
+  module Dynamic
+    # The versions a file binds its symbols to.
+    #
+    # Two tables record them, the versions the file needs of the files it is
+    # loaded with and the versions it defines for what it exports, and a symbol
+    # names one of either by the same index.
+    #
+    # @note
+    #   This module is included by {ELFTools::Dynamic} and reads through the
+    #   methods there, so it cannot be included on its own.
+    module Versions
+      # The versions this file needs of the files it is loaded with.
+      # @return [Array<ELFTools::Dynamic::Versions::Requirement>]
+      #   The requirements, in the order the table records them.
+      # @example
+      #   elf.dynamic.version_requirements.map { |need| [need.file, need.versions.map(&:name)] }
+      #   #=> [['libc.so.6', ['GLIBC_2.4', 'GLIBC_2.2.5']]]
+      def version_requirements
+        @version_requirements ||= read_requirements
+      end
+
+      # The versions this file defines for what it exports.
+      #
+      # The first of them is the file itself rather than a version of it, which
+      # {Definition#base?} tells apart.
+      # @return [Array<ELFTools::Dynamic::Versions::Definition>]
+      #   The definitions, in the order the table records them.
+      # @example
+      #   elf.dynamic.version_definitions.map(&:name).first(3)
+      #   #=> ['libc.so.6', 'GLIBC_2.2.5', 'GLIBC_2.2.6']
+      def version_definitions
+        @version_definitions ||= read_definitions
+      end
+
+      private
+
+      # The version the +n+-th symbol binds to.
+      # @param [Integer] n The symbol index.
+      # @return [ELFTools::Dynamic::Versions::Version, nil]
+      #   The version, +nil+ if the file records none, or if the symbol is one
+      #   of the file's own or of no version at all.
+      def version_at(n)
+        recorded = versym_at(n)
+        return if recorded.nil?
+
+        index = recorded & ~Constants::VER_NDX_HIDDEN
+        return if index <= Constants::VER_NDX_GLOBAL
+
+        name = versions_by_index[index]
+        Version.new(name, index, hidden: !(recorded & Constants::VER_NDX_HIDDEN).zero?) if name
+      end
+
+      # What the +n+-th symbol records as its version.
+      # @return [Integer, nil] The index, +nil+ if the file records none.
+      def versym_at(n)
+        @versym_offset ||= begin
+          tag = tag_by_type(:versym)
+          tag && offset_of(tag)
+        end
+        return if @versym_offset.nil?
+
+        stream.pos = @versym_offset + (n * 2)
+        stream.read(2).to_s.unpack1(endian == :big ? 'S>' : 'S<')
+      end
+
+      # The name each index names, of either table.
+      # @return [Hash{Integer => String}] The names.
+      def versions_by_index
+        @versions_by_index ||=
+          (version_requirements.flat_map(&:versions) + version_definitions).to_h { |v| [v.index, v.name] }
+      end
+
+      # Reads the table +DT_VERNEED+ points at.
+      # @return [Array<ELFTools::Dynamic::Versions::Requirement>] The requirements.
+      def read_requirements
+        each_entry(:verneed, :verneednum, Structs::ELF_Verneed, :vn_next) do |need, at|
+          versions = read_chain(at + need.vn_aux.to_i, need.vn_cnt.to_i, Structs::ELF_Vernaux, :vna_next) do |aux|
+            Version.new(string_table.name_at(aux.vna_name.to_i), aux.vna_other.to_i)
+          end
+          Requirement.new(string_table.name_at(need.vn_file.to_i), versions)
+        end
+      end
+
+      # Reads the table +DT_VERDEF+ points at.
+      # @return [Array<ELFTools::Dynamic::Versions::Definition>] The definitions.
+      def read_definitions
+        each_entry(:verdef, :verdefnum, Structs::ELF_Verdef, :vd_next) do |defn, at|
+          names = read_chain(at + defn.vd_aux.to_i, defn.vd_cnt.to_i, Structs::ELF_Verdaux, :vda_next) do |aux|
+            string_table.name_at(aux.vda_name.to_i)
+          end
+          # The first name is the version's own, the rest are what it descends from.
+          Definition.new(names.first, defn.vd_ndx.to_i, names.drop(1),
+                         base: !(defn.vd_flags.to_i & Constants::VER_FLG_BASE).zero?)
+        end
+      end
+
+      # Reads the entries of a table the tags point at, as many as a tag counts.
+      # @return [Array] What the block makes of each entry.
+      def each_entry(address, count, klass, following)
+        tag = tag_by_type(address)
+        return [] if tag.nil?
+
+        at = offset_of(tag)
+        Array.new(tag_by_type(count).header.d_val.to_i) do
+          entry = read_struct(klass, at)
+          yield(entry, at).tap { at += entry.send(following).to_i }
+        end
+      end
+
+      # Reads a chain of entries, each pointing at the one after it.
+      # @return [Array] What the block makes of each entry.
+      def read_chain(at, count, klass, following)
+        Array.new(count) do
+          entry = read_struct(klass, at)
+          yield(entry).tap { at += entry.send(following).to_i }
+        end
+      end
+
+      # A version a file needs or defines.
+      class Version
+        attr_reader :name # @return [String] The name, +GLIBC_2.2.5+ for instance.
+        attr_reader :index # @return [Integer] The index the symbols name it with.
+
+        # Instantiate a {ELFTools::Dynamic::Versions::Version} object.
+        # @param [String] name The name.
+        # @param [Integer] index The index.
+        # @param [Boolean] hidden Whether a symbol binds to it as a version that is not the default.
+        def initialize(name, index, hidden: false)
+          @name = name
+          @index = index
+          @hidden = hidden
+        end
+
+        # Whether the symbol binding to this version binds to something other
+        # than the default, which is what more than one version of a name means.
+        # @return [Boolean] The answer.
+        def hidden?
+          @hidden
+        end
+      end
+
+      # The versions a file needs of one of the files it is loaded with.
+      class Requirement
+        attr_reader :file # @return [String] The name of the file, +libc.so.6+ for instance.
+        attr_reader :versions # @return [Array<ELFTools::Dynamic::Versions::Version>] The versions needed of it.
+
+        # Instantiate a {ELFTools::Dynamic::Versions::Requirement} object.
+        # @param [String] file The name of the file.
+        # @param [Array<ELFTools::Dynamic::Versions::Version>] versions The versions.
+        def initialize(file, versions)
+          @file = file
+          @versions = versions
+        end
+      end
+
+      # A version a file defines for what it exports.
+      class Definition
+        attr_reader :name # @return [String] The name.
+        attr_reader :index # @return [Integer] The index the symbols name it with.
+        attr_reader :parents # @return [Array<String>] The names of the versions it descends from.
+
+        # Instantiate a {ELFTools::Dynamic::Versions::Definition} object.
+        # @param [String] name The name.
+        # @param [Integer] index The index.
+        # @param [Array<String>] parents The names it descends from.
+        # @param [Boolean] base Whether it names the file rather than a version of it.
+        def initialize(name, index, parents, base: false)
+          @name = name
+          @index = index
+          @parents = parents
+          @base = base
+        end
+
+        # Whether this names the file itself rather than a version of it, which
+        # the first definition of a file does.
+        # @return [Boolean] The answer.
+        def base?
+          @base
+        end
+      end
+    end
+  end
+end

--- a/lib/elftools/sections/symbol.rb
+++ b/lib/elftools/sections/symbol.rb
@@ -20,17 +20,41 @@ module ELFTools
       #   access {Symbol#name}.
       # @param [Integer] machine
       #   The machine of the ELF file, which a name of a value depends on.
-      def initialize(header, stream, symstr: nil, machine: nil)
+      # @param [Proc] version
+      #   Call this to get the version this symbol binds to, which only the
+      #   symbols a file is loaded by have.
+      def initialize(header, stream, symstr: nil, machine: nil, version: nil)
         @header = header
         @stream = stream
         @symstr = symstr
         @machine = machine
+        @version = version
       end
 
       # Return the symbol name.
       # @return [String] The name.
       def name
         @name ||= @symstr.call.name_at(header.st_name)
+      end
+
+      # The version this symbol binds to.
+      #
+      # Only the symbols a file is loaded by have one, and only where the file
+      # records the versions at all. {#name} is left as the file records it,
+      # without the version appended.
+      # @return [String, nil] The name of the version.
+      # @example
+      #   elf.dynamic.symbol_by_name('printf').version
+      #   #=> 'GLIBC_2.2.5'
+      def version
+        binding_version&.name
+      end
+
+      # Whether {#version} is one the symbol asks for by name rather than the
+      # default one of its name.
+      # @return [Boolean] The answer.
+      def version_hidden?
+        binding_version&.hidden? || false
       end
 
       # What kind of entity this symbol refers to.
@@ -127,6 +151,15 @@ module ELFTools
       def visibility_name
         Constants::STV.mapping(@machine, visibility)
       end
+
+      # The version this symbol binds to, whatever is asked of it.
+      # @return [ELFTools::Dynamic::Versions::Version, nil] The version.
+      def binding_version
+        return @binding_version if defined?(@binding_version)
+
+        @binding_version = @version&.call
+      end
+      private :binding_version
 
       # The index of the section this symbol is defined in.
       #

--- a/lib/elftools/structs.rb
+++ b/lib/elftools/structs.rb
@@ -235,6 +235,49 @@ module ELFTools
       uint32 :shift2    # The second shift the bloom filter is built with
     end
 
+    # An entry of the table of versions a file needs of another, which the
+    # +vn_next+ of the one before it points at.
+    class ELF_Verneed < ELFStruct
+      endian :big_and_little
+      uint16 :vn_version # Revision of this structure
+      uint16 :vn_cnt     # How many versions of the file are needed
+      uint32 :vn_file    # Name of the file, as an offset into the string table
+      uint32 :vn_aux     # Where the versions start, as an offset from here
+      uint32 :vn_next    # Where the next entry is, as an offset from here
+    end
+
+    # A version an {ELF_Verneed} needs, which the +vna_next+ of the one before
+    # it points at.
+    class ELF_Vernaux < ELFStruct
+      endian :big_and_little
+      uint32 :vna_hash  # Hash of the name
+      uint16 :vna_flags # Flags
+      uint16 :vna_other # The index the symbols name this version with
+      uint32 :vna_name  # The name, as an offset into the string table
+      uint32 :vna_next  # Where the next version is, as an offset from here
+    end
+
+    # An entry of the table of versions a file defines, which the +vd_next+ of
+    # the one before it points at.
+    class ELF_Verdef < ELFStruct
+      endian :big_and_little
+      uint16 :vd_version # Revision of this structure
+      uint16 :vd_flags   # Flags
+      uint16 :vd_ndx     # The index the symbols name this version with
+      uint16 :vd_cnt     # How many names follow, the version and its ancestors
+      uint32 :vd_hash    # Hash of the name
+      uint32 :vd_aux     # Where the names start, as an offset from here
+      uint32 :vd_next    # Where the next entry is, as an offset from here
+    end
+
+    # A name an {ELF_Verdef} records, its own or an ancestor's, which the
+    # +vda_next+ of the one before it points at.
+    class ELF_Verdaux < ELFStruct
+      endian :big_and_little
+      uint32 :vda_name # The name, as an offset into the string table
+      uint32 :vda_next # Where the next name is, as an offset from here
+    end
+
     # Note header.
     class ELF_Nhdr < ELFStruct
       endian :big_and_little

--- a/spec/versions_spec.rb
+++ b/spec/versions_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'stringio'
+
+require 'elftools/elf_file'
+
+describe ELFTools::Dynamic::Versions do
+  def dynamic(name = 'amd64.elf')
+    ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', name))).dynamic
+  end
+
+  # Returns a file whose tag of +type+ no longer exists.
+  def elf_without_tag(name, type)
+    data = File.binread(File.join(__dir__, 'files', name))
+    header = ELFTools::ELFFile.new(StringIO.new(data)).dynamic.tag_by_type(type).header
+    header.d_tag = ELFTools::Constants::DT_DEBUG
+    data[header.offset, header.num_bytes] = header.to_binary_s
+    ELFTools::ELFFile.new(StringIO.new(data))
+  end
+
+  describe 'version_requirements' do
+    it 'reads what a file needs of the files it is loaded with' do
+      needs = dynamic.version_requirements
+      expect(needs.size).to be 1
+      expect(needs.first.file).to eq 'libc.so.6'
+      expect(needs.first.versions.map(&:name)).to eq %w[GLIBC_2.4 GLIBC_2.2.5]
+      # The index is what a symbol names the version with.
+      expect(needs.first.versions.map(&:index)).to eq [3, 2]
+    end
+
+    it 'reads what a library needs of the loader' do
+      needs = dynamic('libc.so.6').version_requirements
+      expect(needs.map(&:file)).to eq ['ld-linux-x86-64.so.2']
+      expect(needs.first.versions.map(&:name)).to eq %w[GLIBC_2.3 GLIBC_PRIVATE]
+    end
+
+    it 'reads nothing from a file recording none' do
+      expect(elf_without_tag('amd64.elf', :verneed).dynamic.version_requirements).to eq []
+    end
+  end
+
+  describe 'version_definitions' do
+    it 'reads what a library defines' do
+      definitions = dynamic('libc.so.6').version_definitions
+      expect(definitions.size).to be 25
+      # The first names the file rather than a version of it.
+      expect(definitions.first.name).to eq 'libc.so.6'
+      expect(definitions.first).to be_base
+      expect(definitions.first.index).to be 1
+      expect(definitions.first.parents).to eq []
+      # The rest descend from the one before, as glibc versions do.
+      expect(definitions[1].name).to eq 'GLIBC_2.2.5'
+      expect(definitions[1]).not_to be_base
+      expect(definitions[2].name).to eq 'GLIBC_2.2.6'
+      expect(definitions[2].parents).to eq ['GLIBC_2.2.5']
+    end
+
+    it 'reads nothing from a file defining none' do
+      # An executable exports nothing under a version of its own.
+      expect(dynamic.version_definitions).to eq []
+    end
+  end
+
+  describe 'the version a symbol binds to' do
+    it 'names it' do
+      symbols = dynamic.symbols
+      expect(symbols.map(&:version)).to eq [nil, 'GLIBC_2.2.5', 'GLIBC_2.4', 'GLIBC_2.2.5', 'GLIBC_2.2.5',
+                                            'GLIBC_2.2.5', nil, 'GLIBC_2.2.5', 'GLIBC_2.2.5']
+      # The name is left as the file records it.
+      expect(symbols[1].name).to eq 'puts'
+    end
+
+    it 'tells a version asked for by name from the default one' do
+      # More than one version of a name is what makes the others hidden, and
+      # only a library defining versions has them.
+      hidden = dynamic('libc.so.6').symbols.select(&:version_hidden?)
+      expect(hidden.size).to be 51
+      expect(hidden.map(&:name)).to include 'pthread_cond_signal'
+      expect(dynamic.symbols.map(&:version_hidden?)).to all(be false)
+    end
+
+    it 'names none where the file records none' do
+      file = elf_without_tag('amd64.elf', :versym)
+      expect(file.dynamic.symbols.map(&:version)).to all(be nil)
+      expect(file.dynamic.symbols.map(&:version_hidden?)).to all(be false)
+    end
+
+    it 'names none for a symbol read from a section' do
+      # A symbol table that is not the one a file is loaded by has no versions.
+      elf = ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', 'amd64.elf')))
+      symbol = elf.section_by_name('.symtab').symbol_by_name('main')
+      expect(symbol.version).to be nil
+      expect(symbol.version_hidden?).to be false
+    end
+
+    it 'reads them from a file that has no sections left' do
+      data = File.binread(File.join(__dir__, 'files', 'amd64.elf'))
+      header = ELFTools::ELFFile.new(StringIO.new(data)).header
+      header.e_shoff = 0
+      header.e_shnum = 0
+      header.e_shstrndx = 0
+      data[0, header.num_bytes] = header.to_binary_s
+      file = ELFTools::ELFFile.new(StringIO.new(data))
+      expect(file.sections).to be_empty
+      expect(file.dynamic.symbols.map(&:version)).to eq dynamic.symbols.map(&:version)
+      expect(file.dynamic.version_requirements.first.file).to eq 'libc.so.6'
+    end
+  end
+end


### PR DESCRIPTION
A file that is loaded records which version of a name each of its symbols means, so that one library can offer memcpy twice and every caller keeps the one it was built against. Nothing here read it, and a symbol answered with a bare printf where the file records printf at GLIBC_2.2.5.

Two tables hold the names, the versions a file needs of the files it is loaded with and the versions it defines for what it exports, and a symbol names one of either by the same index. Both are read from the tags, which every one of the 2114 versioned files of a system here records alongside the sections and not one records without them, so this stands on a file stripped of its sections as the rest of the dynamic reading does.

The names are what readelf reports, for every versioned symbol of the eight files here that have any, 2288 of them, the bit marking a version asked for by name rather than the default included.

Symbol#name is left alone. Appending the version to it is what nm and readelf do for display, and folding it in here would quietly break every caller looking a bare name up.