### PR TITLE
Read the versions from the sections recording them too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ entries here are collected from those announcements and from the commit history.
 
 ### Added
 
+- `Sections::VersionSection`, `VersionNeedSection`, and `VersionDefinitionSection`, the
+  `.gnu.version`, `.gnu.version_r`, and `.gnu.version_d` sections recording the very
+  versions the tags point at, and `VersionTables`, which reads either view. A symbol read
+  from `.dynsym` answers with its version as one read from the tags does
+  ([#115](https://github.com/david942j/rbelftools/pull/115))
+
 - `Sections::Symbol#version` and `#version_hidden?`, the version a symbol binds to, which
   tells `memcpy@GLIBC_2.14` from the `memcpy@GLIBC_2.2.5` of the same name. `#name` is
   left as the file records it, without the version appended
@@ -29,7 +35,12 @@ entries here are collected from those announcements and from the commit history.
 
 ### Fixed
 
-- `Dynamic#relocations` used to pass over the relocations a file packs into a bitmap, the
+- `sections_by_type` and the other lookups taking a symbol or a string could not name the
+  constants keeping the case an ABI wrote them in, so `sections_by_type(:gnu_verneed)`
+  raised where `SHT_GNU_verneed` is what defines it
+  ([#115](https://github.com/david942j/rbelftools/pull/115))
+- `Dynamic#relocations` used to pass over
+ the relocations a file packs into a bitmap, the
   ones `DT_RELR` points at, and answer with only the tables `DT_REL`, `DT_RELA`, and
   `DT_JMPREL` record. Of the 3780 loaded files of a current system, 557 pack some of
   theirs that way, and across those 46% of their relocations were missing from the answer,

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ dynamic.symbol_by_name('__stack_chk_fail').version
 dynamic.version_requirements.map { |need| [need.file, need.versions.map(&:name)] }
 #=> [["libc.so.6", ["GLIBC_2.4", "GLIBC_2.2.5"]]]
 
+# The sections record the same, for a file that still has them.
+elf.sections_by_type(:gnu_verneed).first.requirements.first.file
+#=> "libc.so.6"
+elf.section_by_name('.dynsym').symbol_by_name('printf').version
+#=> "GLIBC_2.2.5"
+
 # What a library defines, the first naming the library rather than a version of it.
 libc = ELFTools::ELFFile.new(File.open('spec/files/libc.so.6'))
 libc.dynamic.version_definitions.map(&:name).first(3)

--- a/lib/elftools/dynamic/versions.rb
+++ b/lib/elftools/dynamic/versions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'elftools/constants'
-require 'elftools/structs'
+require 'elftools/version_tables'
 
 module ELFTools
   module Dynamic
@@ -16,44 +16,37 @@ module ELFTools
     #   methods there, so it cannot be included on its own.
     module Versions
       # The versions this file needs of the files it is loaded with.
-      # @return [Array<ELFTools::Dynamic::Versions::Requirement>]
+      # @return [Array<ELFTools::VersionTables::Requirement>]
       #   The requirements, in the order the table records them.
       # @example
       #   elf.dynamic.version_requirements.map { |need| [need.file, need.versions.map(&:name)] }
       #   #=> [['libc.so.6', ['GLIBC_2.4', 'GLIBC_2.2.5']]]
       def version_requirements
-        @version_requirements ||= read_requirements
+        @version_requirements ||= read_table(:verneed, :verneednum) { |at, count| tables.requirements(at, count) }
       end
 
       # The versions this file defines for what it exports.
       #
       # The first of them is the file itself rather than a version of it, which
-      # {Definition#base?} tells apart.
-      # @return [Array<ELFTools::Dynamic::Versions::Definition>]
+      # {ELFTools::VersionTables::Definition#base?} tells apart.
+      # @return [Array<ELFTools::VersionTables::Definition>]
       #   The definitions, in the order the table records them.
       # @example
       #   elf.dynamic.version_definitions.map(&:name).first(3)
       #   #=> ['libc.so.6', 'GLIBC_2.2.5', 'GLIBC_2.2.6']
       def version_definitions
-        @version_definitions ||= read_definitions
+        @version_definitions ||= read_table(:verdef, :verdefnum) { |at, count| tables.definitions(at, count) }
       end
 
       private
 
       # The version the +n+-th symbol binds to.
       # @param [Integer] n The symbol index.
-      # @return [ELFTools::Dynamic::Versions::Version, nil]
+      # @return [ELFTools::VersionTables::Version, nil]
       #   The version, +nil+ if the file records none, or if the symbol is one
       #   of the file's own or of no version at all.
       def version_at(n)
-        recorded = versym_at(n)
-        return if recorded.nil?
-
-        index = recorded & ~Constants::VER_NDX_HIDDEN
-        return if index <= Constants::VER_NDX_GLOBAL
-
-        name = versions_by_index[index]
-        Version.new(name, index, hidden: !(recorded & Constants::VER_NDX_HIDDEN).zero?) if name
+        VersionTables.version(versym_at(n), versions_by_index)
       end
 
       # What the +n+-th symbol records as its version.
@@ -69,120 +62,25 @@ module ELFTools
         stream.read(2).to_s.unpack1(endian == :big ? 'S>' : 'S<')
       end
 
-      # The name each index names, of either table.
-      # @return [Hash{Integer => String}] The names.
-      def versions_by_index
-        @versions_by_index ||=
-          (version_requirements.flat_map(&:versions) + version_definitions).to_h { |v| [v.index, v.name] }
+      # The tables the tags point at.
+      # @return [ELFTools::VersionTables] The tables.
+      def tables
+        @tables ||= VersionTables.new(stream, string_table, endian:)
       end
 
-      # Reads the table +DT_VERNEED+ points at.
-      # @return [Array<ELFTools::Dynamic::Versions::Requirement>] The requirements.
-      def read_requirements
-        each_entry(:verneed, :verneednum, Structs::ELF_Verneed, :vn_next) do |need, at|
-          versions = read_chain(at + need.vn_aux.to_i, need.vn_cnt.to_i, Structs::ELF_Vernaux, :vna_next) do |aux|
-            Version.new(string_table.name_at(aux.vna_name.to_i), aux.vna_other.to_i)
-          end
-          Requirement.new(string_table.name_at(need.vn_file.to_i), versions)
-        end
-      end
-
-      # Reads the table +DT_VERDEF+ points at.
-      # @return [Array<ELFTools::Dynamic::Versions::Definition>] The definitions.
-      def read_definitions
-        each_entry(:verdef, :verdefnum, Structs::ELF_Verdef, :vd_next) do |defn, at|
-          names = read_chain(at + defn.vd_aux.to_i, defn.vd_cnt.to_i, Structs::ELF_Verdaux, :vda_next) do |aux|
-            string_table.name_at(aux.vda_name.to_i)
-          end
-          # The first name is the version's own, the rest are what it descends from.
-          Definition.new(names.first, defn.vd_ndx.to_i, names.drop(1),
-                         base: !(defn.vd_flags.to_i & Constants::VER_FLG_BASE).zero?)
-        end
-      end
-
-      # Reads the entries of a table the tags point at, as many as a tag counts.
-      # @return [Array] What the block makes of each entry.
-      def each_entry(address, count, klass, following)
+      # Reads a table the tags point at, as many entries as a tag counts.
+      # @return [Array] What the block makes of it, empty without the tags.
+      def read_table(address, count)
         tag = tag_by_type(address)
         return [] if tag.nil?
 
-        at = offset_of(tag)
-        Array.new(tag_by_type(count).header.d_val.to_i) do
-          entry = read_struct(klass, at)
-          yield(entry, at).tap { at += entry.send(following).to_i }
-        end
+        yield(offset_of(tag), tag_by_type(count).header.d_val.to_i)
       end
 
-      # Reads a chain of entries, each pointing at the one after it.
-      # @return [Array] What the block makes of each entry.
-      def read_chain(at, count, klass, following)
-        Array.new(count) do
-          entry = read_struct(klass, at)
-          yield(entry).tap { at += entry.send(following).to_i }
-        end
-      end
-
-      # A version a file needs or defines.
-      class Version
-        attr_reader :name # @return [String] The name, +GLIBC_2.2.5+ for instance.
-        attr_reader :index # @return [Integer] The index the symbols name it with.
-
-        # Instantiate a {ELFTools::Dynamic::Versions::Version} object.
-        # @param [String] name The name.
-        # @param [Integer] index The index.
-        # @param [Boolean] hidden Whether a symbol binds to it as a version that is not the default.
-        def initialize(name, index, hidden: false)
-          @name = name
-          @index = index
-          @hidden = hidden
-        end
-
-        # Whether the symbol binding to this version binds to something other
-        # than the default, which is what more than one version of a name means.
-        # @return [Boolean] The answer.
-        def hidden?
-          @hidden
-        end
-      end
-
-      # The versions a file needs of one of the files it is loaded with.
-      class Requirement
-        attr_reader :file # @return [String] The name of the file, +libc.so.6+ for instance.
-        attr_reader :versions # @return [Array<ELFTools::Dynamic::Versions::Version>] The versions needed of it.
-
-        # Instantiate a {ELFTools::Dynamic::Versions::Requirement} object.
-        # @param [String] file The name of the file.
-        # @param [Array<ELFTools::Dynamic::Versions::Version>] versions The versions.
-        def initialize(file, versions)
-          @file = file
-          @versions = versions
-        end
-      end
-
-      # A version a file defines for what it exports.
-      class Definition
-        attr_reader :name # @return [String] The name.
-        attr_reader :index # @return [Integer] The index the symbols name it with.
-        attr_reader :parents # @return [Array<String>] The names of the versions it descends from.
-
-        # Instantiate a {ELFTools::Dynamic::Versions::Definition} object.
-        # @param [String] name The name.
-        # @param [Integer] index The index.
-        # @param [Array<String>] parents The names it descends from.
-        # @param [Boolean] base Whether it names the file rather than a version of it.
-        def initialize(name, index, parents, base: false)
-          @name = name
-          @index = index
-          @parents = parents
-          @base = base
-        end
-
-        # Whether this names the file itself rather than a version of it, which
-        # the first definition of a file does.
-        # @return [Boolean] The answer.
-        def base?
-          @base
-        end
+      # The name each index names, of either table.
+      # @return [Hash{Integer => String}] The names.
+      def versions_by_index
+        @versions_by_index ||= VersionTables.names(version_requirements, version_definitions)
       end
     end
   end

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -413,6 +413,7 @@ module ELFTools
                                offset_from_vma: method(:offset_from_vma),
                                section_name_table: method(:section_name_table),
                                section_at: method(:section_at),
+                               sections: method(:sections),
                                machine: header.e_machine.to_i)
     end
 

--- a/lib/elftools/sections/sections.rb
+++ b/lib/elftools/sections/sections.rb
@@ -11,6 +11,9 @@ require 'elftools/sections/relative_relocation_section'
 require 'elftools/sections/relocation_section'
 require 'elftools/sections/str_tab_section'
 require 'elftools/sections/sym_tab_section'
+require 'elftools/sections/version_definition_section'
+require 'elftools/sections/version_need_section'
+require 'elftools/sections/version_section'
 
 module ELFTools
   # Defines different types of sections in this module.
@@ -29,6 +32,9 @@ module ELFTools
                 when Constants::SHT_NOTE then NoteSection
                 when Constants::SHT_RELA, Constants::SHT_REL then RelocationSection
                 when Constants::SHT_RELR then RelativeRelocationSection
+                when Constants::SHT_GNU_versym then VersionSection
+                when Constants::SHT_GNU_verneed then VersionNeedSection
+                when Constants::SHT_GNU_verdef then VersionDefinitionSection
                 when Constants::SHT_STRTAB then StrTabSection
                 when Constants::SHT_SYMTAB, Constants::SHT_DYNSYM then SymTabSection
                 else Section

--- a/lib/elftools/sections/sym_tab_section.rb
+++ b/lib/elftools/sections/sym_tab_section.rb
@@ -2,6 +2,7 @@
 
 require 'elftools/sections/section'
 require 'elftools/sections/symbol'
+require 'elftools/version_tables'
 
 module ELFTools
   module Sections
@@ -16,14 +17,15 @@ module ELFTools
       #   See {Section#initialize} for more information.
       # @param [#pos=, #read] stream
       #   See {Section#initialize} for more information.
-      # @param [Proc] section_at
-      #   The method for fetching other sections by index.
-      #   This lambda should be {ELFTools::ELFFile#section_at}.
+      # @param [Proc] sections
+      #   The method for fetching the sections, which is where the names and
+      #   the versions of these symbols are recorded. This lambda should be
+      #   {ELFTools::ELFFile#sections}.
       # @param [Integer] machine
       #   The machine of the ELF file, which decides what the fields of a
       #   symbol mean. This should be +e_machine+ of the ELF header.
-      def initialize(header, stream, section_at: nil, machine: nil, **_kwargs)
-        @section_at = section_at
+      def initialize(header, stream, sections: nil, machine: nil, **_kwargs)
+        @sections = sections
         @machine = machine
         # For faster #symbol_by_name
         super
@@ -91,7 +93,7 @@ module ELFTools
       # Lazy loaded.
       # @return [ELFTools::Sections::StrTabSection] The string table section.
       def symstr
-        @symstr ||= @section_at.call(header.sh_link)
+        @symstr ||= @sections.call[header.sh_link]
       end
 
       private
@@ -100,7 +102,37 @@ module ELFTools
         stream.pos = header.sh_offset + n * header.sh_entsize
         sym = Structs::ELF_sym[header.elf_class].new(endian: header.class.self_endian, offset: stream.pos)
         sym.read(stream)
-        Symbol.new(sym, stream, symstr: method(:symstr), machine: @machine)
+        Symbol.new(sym, stream, symstr: method(:symstr), machine: @machine, version: -> { version_at(n) })
+      end
+
+      # The version the +n+-th symbol binds to.
+      # @return [ELFTools::VersionTables::Version, nil]
+      #   The version, +nil+ unless this is the table a file is loaded by and
+      #   the file records versions at all.
+      def version_at(n)
+        return if versions.nil?
+
+        VersionTables.version(versions.version_at(n), versions_by_index)
+      end
+
+      # The section recording which version each of these symbols binds to,
+      # which is the one naming this table.
+      # @return [ELFTools::Sections::VersionSection, nil] The section.
+      def versions
+        return @versions if defined?(@versions)
+
+        @versions = @sections&.call&.find do |sec|
+          sec.is_a?(VersionSection) && @sections.call[sec.header.sh_link].equal?(self)
+        end
+      end
+
+      # The name each index the symbols record names.
+      # @return [Hash{Integer => String}] The names.
+      def versions_by_index
+        @versions_by_index ||= VersionTables.names(
+          @sections.call.grep(VersionNeedSection).flat_map(&:requirements),
+          @sections.call.grep(VersionDefinitionSection).flat_map(&:definitions)
+        )
       end
     end
   end

--- a/lib/elftools/sections/version_definition_section.rb
+++ b/lib/elftools/sections/version_definition_section.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'elftools/sections/section'
+require 'elftools/version_tables'
+
+module ELFTools
+  module Sections
+    # Class of the section recording the versions a file defines for what it
+    # exports.
+    #
+    # This section is usually named .gnu.version_d, and records the very
+    # versions the +DT_VERDEF+ tag points at.
+    class VersionDefinitionSection < Section
+      # Instantiate a {VersionDefinitionSection} object.
+      # @param [ELFTools::Structs::ELF_Shdr] header
+      #   See {Section#initialize} for more information.
+      # @param [#pos=, #read] stream
+      #   See {Section#initialize} for more information.
+      # @param [Proc] section_at
+      #   The method for fetching other sections by index, which is where the
+      #   names are recorded.
+      def initialize(header, stream, section_at: nil, **_kwargs)
+        @section_at = section_at
+        super
+      end
+
+      # The versions this file defines for what it exports.
+      # @return [Array<ELFTools::VersionTables::Definition>]
+      #   The definitions, in the order the section records them.
+      # @example
+      #   section.definitions.map(&:name).first(3)
+      #   #=> ['libc.so.6', 'GLIBC_2.2.5', 'GLIBC_2.2.6']
+      def definitions
+        @definitions ||= VersionTables.new(stream, @section_at.call(header.sh_link),
+                                           endian: header.class.self_endian)
+                                      .definitions(header.sh_offset.to_i, header.sh_info.to_i)
+      end
+    end
+  end
+end

--- a/lib/elftools/sections/version_need_section.rb
+++ b/lib/elftools/sections/version_need_section.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'elftools/sections/section'
+require 'elftools/version_tables'
+
+module ELFTools
+  module Sections
+    # Class of the section recording the versions a file needs of the files it
+    # is loaded with.
+    #
+    # This section is usually named .gnu.version_r, and records the very
+    # versions the +DT_VERNEED+ tag points at.
+    class VersionNeedSection < Section
+      # Instantiate a {VersionNeedSection} object.
+      # @param [ELFTools::Structs::ELF_Shdr] header
+      #   See {Section#initialize} for more information.
+      # @param [#pos=, #read] stream
+      #   See {Section#initialize} for more information.
+      # @param [Proc] section_at
+      #   The method for fetching other sections by index, which is where the
+      #   names are recorded.
+      def initialize(header, stream, section_at: nil, **_kwargs)
+        @section_at = section_at
+        super
+      end
+
+      # The versions this file needs of the files it is loaded with.
+      # @return [Array<ELFTools::VersionTables::Requirement>]
+      #   The requirements, in the order the section records them.
+      # @example
+      #   section.requirements.map { |need| [need.file, need.versions.map(&:name)] }
+      #   #=> [['libc.so.6', ['GLIBC_2.4', 'GLIBC_2.2.5']]]
+      def requirements
+        @requirements ||= VersionTables.new(stream, @section_at.call(header.sh_link),
+                                            endian: header.class.self_endian)
+                                       .requirements(header.sh_offset.to_i, header.sh_info.to_i)
+      end
+    end
+  end
+end

--- a/lib/elftools/sections/version_section.rb
+++ b/lib/elftools/sections/version_section.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'elftools/sections/section'
+
+module ELFTools
+  module Sections
+    # Class of the section recording which version each symbol binds to.
+    #
+    # This section is usually named .gnu.version, and holds an index per symbol
+    # of the table its +sh_link+ names, the very indices the +DT_VERSYM+ tag
+    # points at.
+    class VersionSection < Section
+      # How many symbols the section records a version for.
+      # @return [Integer] The number.
+      def num_versions
+        header.sh_size.to_i / entry_size
+      end
+
+      # What the +n+-th symbol records as its version, which is an index into
+      # the versions a file needs or defines, with the highest bit marking a
+      # version the symbol asks for by name rather than the default one.
+      # @param [Integer] n The symbol index.
+      # @return [Integer, nil] The index, +nil+ if the section records none for it.
+      # @example
+      #   section.version_at(1)
+      #   #=> 2
+      def version_at(n)
+        return if n.negative? || n >= num_versions
+
+        stream.pos = header.sh_offset.to_i + (n * entry_size)
+        stream.read(entry_size).unpack1(header.class.self_endian == :big ? 'S>' : 'S<')
+      end
+
+      private
+
+      # What an entry takes, which the section records and the format fixes at
+      # two bytes either way.
+      # @return [Integer] The number of bytes.
+      def entry_size
+        2
+      end
+    end
+  end
+end

--- a/lib/elftools/util.rb
+++ b/lib/elftools/util.rb
@@ -66,9 +66,12 @@ module ELFTools
         prefix = module_name.split('::')[-1]
         val = "#{prefix}_#{val}" unless val.start_with?(prefix)
         val = val.to_sym
-        raise ArgumentError, "No constants in #{module_name} named \"#{val}\"" unless mod.const_defined?(val)
+        # Whichever way the constant spells it, some of them keeping the case
+        # the ABI wrote them in, +SHT_GNU_verneed+ for one.
+        name = mod.constants.find { |constant| constant.to_s.upcase == val.to_s }
+        raise ArgumentError, "No constants in #{module_name} named \"#{val}\"" if name.nil?
 
-        mod.const_get(val)
+        mod.const_get(name)
       end
 
       # Read from stream until reach a null-byte.

--- a/lib/elftools/version_tables.rb
+++ b/lib/elftools/version_tables.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'elftools/constants'
+require 'elftools/structs'
+
+module ELFTools
+  # The two tables a file records its versions in.
+  #
+  # One holds the versions the file needs of the files it is loaded with, the
+  # other the versions it defines for what it exports, and a symbol names one
+  # of either by the same index. Both are chains, each entry saying how far
+  # off the next one is, and both are recorded twice over: the tags point at
+  # them, and so do sections.
+  class VersionTables
+    # The name each index of either table names.
+    # @param [Array<ELFTools::VersionTables::Requirement>] requirements The requirements.
+    # @param [Array<ELFTools::VersionTables::Definition>] definitions The definitions.
+    # @return [Hash{Integer => String}] The names.
+    def self.names(requirements, definitions)
+      (requirements.flat_map(&:versions) + definitions).to_h { |version| [version.index, version.name] }
+    end
+
+    # The version a symbol records, read against the names of the tables.
+    # @param [Integer, nil] recorded
+    #   What the symbol records, which is an index with the highest bit marking
+    #   a version asked for by name rather than the default one.
+    # @param [Hash{Integer => String}] names What {names} answered.
+    # @return [ELFTools::VersionTables::Version, nil]
+    #   The version, +nil+ where the symbol names none: a symbol of the file
+    #   itself, a symbol of no version at all, and a name nothing records.
+    def self.version(recorded, names)
+      return if recorded.nil?
+
+      index = recorded & ~Constants::VER_NDX_HIDDEN
+      return if index <= Constants::VER_NDX_GLOBAL
+
+      name = names[index]
+      Version.new(name, index, hidden: !(recorded & Constants::VER_NDX_HIDDEN).zero?) if name
+    end
+
+    # Instantiate a {ELFTools::VersionTables} object.
+    # @param [#pos=, #read] stream Streaming object.
+    # @param [#name_at] strtab The table the names are recorded in.
+    # @param [Symbol] endian +:little+ or +:big+.
+    def initialize(stream, strtab, endian:)
+      @stream = stream
+      @strtab = strtab
+      @endian = endian
+    end
+
+    # Reads the versions a file needs of the files it is loaded with.
+    # @param [Integer] at The file offset the table starts at.
+    # @param [Integer] count How many entries it has.
+    # @return [Array<ELFTools::VersionTables::Requirement>] The requirements.
+    def requirements(at, count)
+      chain(at, count, Structs::ELF_Verneed, :vn_next) do |need, from|
+        versions = chain(from + need.vn_aux.to_i, need.vn_cnt.to_i, Structs::ELF_Vernaux, :vna_next) do |aux, _|
+          Version.new(@strtab.name_at(aux.vna_name.to_i), aux.vna_other.to_i)
+        end
+        Requirement.new(@strtab.name_at(need.vn_file.to_i), versions)
+      end
+    end
+
+    # Reads the versions a file defines for what it exports.
+    # @param [Integer] at The file offset the table starts at.
+    # @param [Integer] count How many entries it has.
+    # @return [Array<ELFTools::VersionTables::Definition>] The definitions.
+    def definitions(at, count)
+      chain(at, count, Structs::ELF_Verdef, :vd_next) do |defn, from|
+        names = chain(from + defn.vd_aux.to_i, defn.vd_cnt.to_i, Structs::ELF_Verdaux, :vda_next) do |aux, _|
+          @strtab.name_at(aux.vda_name.to_i)
+        end
+        # The first name is the version's own, the rest are what it descends from.
+        Definition.new(names.first, defn.vd_ndx.to_i, names.drop(1),
+                       base: !(defn.vd_flags.to_i & Constants::VER_FLG_BASE).zero?)
+      end
+    end
+
+    private
+
+    # Reads a chain of entries, each saying how far off the one after it is.
+    # @return [Array] What the block makes of each entry.
+    def chain(at, count, klass, following)
+      Array.new(count) do
+        entry = klass.new(endian: @endian, offset: at)
+        @stream.pos = at
+        entry.read(@stream)
+        yield(entry, at).tap { at += entry.send(following).to_i }
+      end
+    end
+
+    # A version a file needs or defines.
+    class Version
+      attr_reader :name # @return [String] The name, +GLIBC_2.2.5+ for instance.
+      attr_reader :index # @return [Integer] The index the symbols name it with.
+
+      # Instantiate a {ELFTools::VersionTables::Version} object.
+      # @param [String] name The name.
+      # @param [Integer] index The index.
+      # @param [Boolean] hidden Whether a symbol binds to it as a version that is not the default.
+      def initialize(name, index, hidden: false)
+        @name = name
+        @index = index
+        @hidden = hidden
+      end
+
+      # Whether the symbol binding to this version binds to something other
+      # than the default, which is what more than one version of a name means.
+      # @return [Boolean] The answer.
+      def hidden?
+        @hidden
+      end
+    end
+
+    # The versions a file needs of one of the files it is loaded with.
+    class Requirement
+      attr_reader :file # @return [String] The name of the file, +libc.so.6+ for instance.
+      attr_reader :versions # @return [Array<ELFTools::VersionTables::Version>] The versions needed of it.
+
+      # Instantiate a {ELFTools::VersionTables::Requirement} object.
+      # @param [String] file The name of the file.
+      # @param [Array<ELFTools::VersionTables::Version>] versions The versions.
+      def initialize(file, versions)
+        @file = file
+        @versions = versions
+      end
+    end
+
+    # A version a file defines for what it exports.
+    class Definition
+      attr_reader :name # @return [String] The name.
+      attr_reader :index # @return [Integer] The index the symbols name it with.
+      attr_reader :parents # @return [Array<String>] The names of the versions it descends from.
+
+      # Instantiate a {ELFTools::VersionTables::Definition} object.
+      # @param [String] name The name.
+      # @param [Integer] index The index.
+      # @param [Array<String>] parents The names it descends from.
+      # @param [Boolean] base Whether it names the file rather than a version of it.
+      def initialize(name, index, parents, base: false)
+        @name = name
+        @index = index
+        @parents = parents
+        @base = base
+      end
+
+      # Whether this names the file itself rather than a version of it, which
+      # the first definition of a file does.
+      # @return [Boolean] The answer.
+      def base?
+        @base
+      end
+    end
+  end
+end

--- a/spec/versions_spec.rb
+++ b/spec/versions_spec.rb
@@ -106,4 +106,55 @@ describe ELFTools::Dynamic::Versions do
       expect(file.dynamic.version_requirements.first.file).to eq 'libc.so.6'
     end
   end
+  describe 'the sections recording the same' do
+    def elf(name = 'amd64.elf')
+      ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', name)))
+    end
+
+    it 'reads each of them as a class of its own' do
+      file = elf('libc.so.6')
+      expect(file.section_by_name('.gnu.version')).to be_a ELFTools::Sections::VersionSection
+      expect(file.section_by_name('.gnu.version_r')).to be_a ELFTools::Sections::VersionNeedSection
+      expect(file.section_by_name('.gnu.version_d')).to be_a ELFTools::Sections::VersionDefinitionSection
+    end
+
+    it 'answers what the tags answer' do
+      # Both views describe the same bytes, so each answers for the other.
+      %w[amd64.elf libc.so.6 aarch64.elf i386.pie.elf].each do |name|
+        file = elf(name)
+        summarize = ->(needs) { needs.map { |need| [need.file, need.versions.map(&:name)] } }
+        expect(summarize.call(file.sections_by_type(:gnu_verneed).flat_map(&:requirements)))
+          .to eq summarize.call(file.dynamic.version_requirements)
+
+        defines = file.sections_by_type(:gnu_verdef).flat_map(&:definitions)
+        expect(defines.map(&:name)).to eq file.dynamic.version_definitions.map(&:name)
+      end
+    end
+
+    it 'records an index for every symbol' do
+      versions = elf('libc.so.6').section_by_name('.gnu.version')
+      expect(versions.num_versions).to be 2245
+      expect(versions.num_versions).to eq elf('libc.so.6').section_by_name('.dynsym').num_symbols
+      # The first symbol is the file's own, which binds to no version.
+      expect(versions.version_at(0)).to be 0
+      expect(versions.version_at(-1)).to be nil
+      expect(versions.version_at(2245)).to be nil
+    end
+
+    it 'names the version of a symbol read from a section' do
+      # The very versions the tags name, for the symbols of the same table.
+      %w[amd64.elf libc.so.6].each do |name|
+        file = elf(name)
+        from_sections = file.section_by_name('.dynsym').symbols
+        from_tags = file.dynamic.symbols
+        expect(from_sections.map(&:version)).to eq from_tags.map(&:version)
+        expect(from_sections.map(&:version_hidden?)).to eq from_tags.map(&:version_hidden?)
+      end
+    end
+
+    it 'names none for a table a file is not loaded by' do
+      # Nothing records a version for .symtab, which no section names.
+      expect(elf.section_by_name('.symtab').symbols.map(&:version)).to all(be nil)
+    end
+  end
 end


### PR DESCRIPTION
The tags and the sections describe the same two tables, as they do for relocations and symbols, so .gnu.version_r and .gnu.version_d are read as classes of their own now and a symbol of .dynsym answers with its version the way one read from the tags does. Both views agree, name for name, for every file here that records any.

The parsing moves to VersionTables, which either view hands a stream, a string table and an endianness, and which also decides what an index means so that neither view decides it twice. What a section takes it from its own header, the count from sh_info and the names from sh_link, where the tags take it from DT_VERNEEDNUM and DT_VERDEFNUM.

A symbol table reaches the sections through one method rather than two, because finding the versions means looking for the section that names it rather than one it names.

Six constants could not be named by symbol along the way: to_constant upcased what it was given and asked for that exactly, so the ones keeping the case an ABI wrote them in were unreachable, and sections_by_type with :gnu_verneed raised rather than answering with .gnu.version_r.