### PR TITLE
Answer with what a symbol is worth and how large it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ entries here are collected from those announcements and from the commit history.
 
 ### Added
 
+- `Sections::Symbol#value` and `#size`, the last of what a symbol records that took
+  reaching into its header. What a symbol is worth is the address of what it names in a
+  file that is loaded, an offset into the section holding it in one that is not, and the
+  alignment it needs where the linker is still to place it
+  ([#116](https://github.com/david942j/rbelftools/pull/116))
+
 - `Sections::VersionSection`, `VersionNeedSection`, and `VersionDefinitionSection`, the
   `.gnu.version`, `.gnu.version_r`, and `.gnu.version_d` sections recording the very
   versions the tags point at, and `VersionTables`, which reads either view. A symbol read

--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ symbols.map(&:name).reject(&:empty?).first(5).join(' ')
 #=> "crtstuff.c __JCR_LIST__ deregister_tm_clones register_tm_clones __do_global_dtors_aux"
 ```
 
+Where a symbol is and how large it is:
+```ruby
+main = symtab_section.symbol_by_name('main')
+'%#x' % main.value
+#=> "0x4006dd"
+main.size
+#=> 142
+```
+
 What a symbol refers to and how it is linked are recorded in `st_info` and `st_other`,
 values are defined in `ELFTools::Constants::STT`, `STB`, and `STV` respectively.
 ```ruby

--- a/lib/elftools/sections/symbol.rb
+++ b/lib/elftools/sections/symbol.rb
@@ -57,6 +57,31 @@ module ELFTools
         binding_version&.hidden? || false
       end
 
+      # What this symbol is worth, which for most of them is the address of
+      # what they name.
+      #
+      # A symbol of a file that is not loaded anywhere records an offset into
+      # the section holding it instead, and one the linker is still to place,
+      # which {ELFTools::Constants::SHN_COMMON} marks, records the alignment it
+      # needs. The ABI leaves the field to the kind of symbol for that reason,
+      # and this answers with what is recorded either way.
+      # @return [Integer] The value.
+      # @example
+      #   elf.section_by_name('.symtab').symbol_by_name('main').value
+      #   #=> 4196061 # 0x4006dd
+      def value
+        header.st_value.to_i
+      end
+
+      # How many bytes what this symbol names takes.
+      # @return [Integer] The number, zero where the file records none.
+      # @example
+      #   elf.section_by_name('.symtab').symbol_by_name('main').size
+      #   #=> 142
+      def size
+        header.st_size.to_i
+      end
+
       # What kind of entity this symbol refers to.
       #
       # The available types are listed in {ELFTools::Constants::STT}.

--- a/spec/symbol_spec.rb
+++ b/spec/symbol_spec.rb
@@ -110,4 +110,22 @@ describe ELFTools::Sections::Symbol do
       .to eq %w[STT_OBJECT STB_WEAK STV_HIDDEN]
     out.close!
   end
+  it 'value' do
+    # What a symbol of a file that is loaded is worth is the address of what
+    # it names.
+    expect(@symtab.symbol_by_name('main').value).to be 0x4006dd
+    expect(@symtab.symbol_by_name('main').value).to eq @symtab.symbol_by_name('main').header.st_value
+    # A file that is not loaded anywhere records an offset into the section
+    # holding it instead.
+    relocatable = ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', 'mips.o')))
+    helper = relocatable.section_by_name('.symtab').symbol_by_name('_ZL6helperi')
+    expect(helper.value).to be 132
+    expect(helper.section_index).to be 2
+  end
+
+  it 'size' do
+    expect(@symtab.symbol_by_name('main').size).to be 142
+    # A symbol the file records no size for, of which every file has some.
+    expect(@symtab.symbol_by_name('crtstuff.c').size).to be 0
+  end
 end


### PR DESCRIPTION
st_value and st_size were the last of what a symbol records that took reaching into its header, where the type, the binding, the visibility, the section index and the version all answer for themselves.

What a symbol is worth is the address of what it names in a file that is loaded, an offset into the section holding it in one that is not, and the alignment it needs where the linker is still to place it, so the name is the one the ABI leaves as generic as the field.