### PR TITLE
Say what a section is for, as a segment already says

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ entries here are collected from those announcements and from the commit history.
 
 ### Added
 
+- `Sections::Section#writable?`, `#executable?`, and `#allocated?`, which read `sh_flags`
+  the way `Segments::Segment` already reads `p_flags`. A section is allocated when it takes
+  memory while the file runs, which is what tells the sections a file is loaded by from the
+  ones only recorded about it ([#117](https://github.com/david942j/rbelftools/pull/117))
+
 - `Sections::VersionSection`, `VersionNeedSection`, and `VersionDefinitionSection`, the
   `.gnu.version`, `.gnu.version_r`, and `.gnu.version_d` sections recording the very
   versions the tags point at, and `VersionTables`, which reads either view. A symbol read

--- a/README.md
+++ b/README.md
@@ -186,6 +186,19 @@ libc.dynamic.symbol_by_name('malloc').type_name
 #=> "STT_FUNC"
 ```
 
+What a section is for is recorded in `sh_flags`, as a segment records it in `p_flags`.
+```ruby
+[elf.section_by_name('.text').executable?, elf.section_by_name('.text').writable?]
+#=> [true, false]
+
+# Only some of the sections take memory while the file runs, the rest being what is
+# recorded about it.
+elf.sections.select(&:allocated?).map(&:name).first(5).join(' ')
+#=> ".interp .note.ABI-tag .note.gnu.build-id .gnu.hash .dynsym"
+elf.sections.reject(&:allocated?).map(&:name).reject(&:empty?).join(' ')
+#=> ".comment .shstrtab .symtab .strtab"
+```
+
 ## Segments
 
 ```ruby

--- a/lib/elftools/sections/section.rb
+++ b/lib/elftools/sections/section.rb
@@ -46,6 +46,37 @@ module ELFTools
         stream.read(header.sh_size)
       end
 
+      # Is this section written to while the file runs?
+      # @return [Boolean] True or false.
+      # @example
+      #   elf.section_by_name('.data').writable?
+      #   #=> true
+      def writable?
+        header.sh_flags.allbits?(Constants::SHF_WRITE)
+      end
+
+      # Is this section executed?
+      # @return [Boolean] True or false.
+      # @example
+      #   elf.section_by_name('.text').executable?
+      #   #=> true
+      def executable?
+        header.sh_flags.allbits?(Constants::SHF_EXECINSTR)
+      end
+
+      # Does this section take memory while the file runs?
+      #
+      # The ones that do are what a file is loaded by, the rest being what is
+      # recorded about it, its symbol names and its debugging information
+      # among them.
+      # @return [Boolean] True or false.
+      # @example
+      #   elf.section_by_name('.symtab').allocated?
+      #   #=> false
+      def allocated?
+        header.sh_flags.allbits?(Constants::SHF_ALLOC)
+      end
+
       # Is this a null section?
       # @return [Boolean] No it's not.
       def null?

--- a/spec/sections_spec.rb
+++ b/spec/sections_spec.rb
@@ -1,6 +1,7 @@
 # encoding: ascii-8bit
 # frozen_string_literal: true
 
+require 'elftools/elf_file'
 require 'elftools/sections/sections'
 require 'elftools/structs'
 
@@ -42,6 +43,47 @@ describe ELFTools::Sections do
       note = ELFTools::Sections::Section.create(@header_maker.call(type: 7), nil)
       expect(note).to be_a ELFTools::Sections::NoteSection
       expect(note.respond_to?(:notes)).to be true
+    end
+  end
+  describe 'what a section is for' do
+    before(:all) do
+      filepath = File.join(__dir__, 'files', 'amd64.elf')
+      @elf = ELFTools::ELFFile.new(File.open(filepath))
+    end
+
+    it 'says which are written to and which are executed' do
+      expect(@elf.section_by_name('.text')).to be_executable
+      expect(@elf.section_by_name('.text')).not_to be_writable
+      expect(@elf.section_by_name('.data')).to be_writable
+      expect(@elf.section_by_name('.data')).not_to be_executable
+      expect(@elf.section_by_name('.rodata')).not_to be_writable
+      expect(@elf.section_by_name('.rodata')).not_to be_executable
+    end
+
+    it 'says which take memory while the file runs' do
+      # What the file is loaded by, against what is only recorded about it.
+      expect(@elf.section_by_name('.text')).to be_allocated
+      expect(@elf.section_by_name('.bss')).to be_allocated
+      expect(@elf.section_by_name('.symtab')).not_to be_allocated
+      expect(@elf.section_by_name('.shstrtab')).not_to be_allocated
+    end
+
+    it 'says the same of a section of any file' do
+      # A section taking memory is a section a segment takes memory for, so
+      # the two views have to agree. What is compared is the memory a segment
+      # takes and not the bytes it is read from, .bss taking the one without
+      # occupying any of the other.
+      %w[amd64.elf ppc64.elf i386.pie.elf].each do |name|
+        elf = ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', name)))
+        loaded = elf.segments_by_type(:load)
+        elf.sections.each do |section|
+          address = section.header.sh_addr.to_i
+          next if section.null? || address.zero?
+
+          covered = loaded.any? { |seg| address >= seg.mem_head && address < seg.mem_tail }
+          expect(section.allocated?).to be covered
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
A segment answers whether it is readable, writable and executable, and a section answered nothing of the kind, leaving sh_flags to the caller.

So writable?, executable?, and allocated?, the last of which is what tells the sections a file is loaded by from the ones only recorded about it, its symbol names and its comments among them. All three are what readelf reports, for every section of amd64.elf, libc.so.6, ppc64.elf and aarch64.relr.elf.

A spec of mine asserted that an allocated section is one a load segment covers, and .bss proved it wrong: it takes memory while occupying no bytes of the file, which #83 made vma_in? answer no for. What a segment takes memory for is what it is compared against now.