### PR TITLE
Count the symbols from the table that counts them (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,15 @@ entries here are collected from those announcements and from the commit history.
   is nested, and a field assigned the value it already held leaves nothing behind.
   `Structs::ELFStruct.pack` is no longer how a patch is made, and is deprecated
   ([#111](https://github.com/david942j/rbelftools/pull/111))
+- `Dynamic#num_symbols` answers with what `DT_HASH` counts where a file records that
+  table, instead of reading every relocation in the file to bound a number the table
+  already states. A chain of that table belongs to every symbol, so nothing a file records
+  reaches past it. A file recording no such table is counted as before. The size of an
+  entry is also measured once for the table rather than once per symbol, which used to
+  cost a structure of its own each time. Reading the symbols the tags point at is well
+  over twice as fast for it, and what is read is unchanged, name for name and index for
+  index
+  ([#119](https://github.com/david942j/rbelftools/pull/119))
 
 ## 2.0.0 - 2026-08-24
 

--- a/lib/elftools/dynamic/hash_table.rb
+++ b/lib/elftools/dynamic/hash_table.rb
@@ -24,6 +24,13 @@ module ELFTools
         @endian = endian
       end
 
+      # Whether {#num_symbols} is how many symbols there are rather than how
+      # far the table reaches, which only a table indexing every symbol knows.
+      # @return [Boolean] The answer.
+      def records_num_symbols?
+        false
+      end
+
       private
 
       # The header the table starts with.
@@ -64,6 +71,11 @@ module ELFTools
         # @return [Integer] The number.
         def num_symbols
           header.nchain.to_i
+        end
+
+        # (see ELFTools::Dynamic::HashTable#records_num_symbols?)
+        def records_num_symbols?
+          true
         end
 
         # The index a name sits at.

--- a/lib/elftools/dynamic/symbols.rb
+++ b/lib/elftools/dynamic/symbols.rb
@@ -30,10 +30,7 @@ module ELFTools
 
         @symbol_at_map ||= {}
         @symbol_at_map[n] ||= begin
-          klass = Structs::ELF_sym[header.elf_class]
-          # An entry takes what its structure takes, which is also what
-          # DT_SYMENT records and what a file has no way of disagreeing with.
-          sym = read_struct(klass, sym_offset + (n * struct(klass).num_bytes))
+          sym = read_struct(Structs::ELF_sym[header.elf_class], sym_offset + (n * sym_entsize))
           Sections::Symbol.new(sym, stream, symstr: method(:string_table), machine: @machine,
                                             version: -> { version_at(n) })
         end
@@ -41,15 +38,18 @@ module ELFTools
 
       # How many symbols the tags reach.
       #
-      # Nothing a file is loaded by records how large its symbol table is. The
-      # loader never enumerates it: it looks a name up through a hash table and
-      # jumps straight to an index, so where the table ends is none of its
-      # business. Two things bound it instead, the hash table that indexes the
-      # names a file exports and the relocations that name a symbol by index,
-      # and the answer is how far the further of the two reaches. Only +DT_HASH+
-      # records the number outright.
+      # A hash table that records the number outright is answered with, because
+      # nothing a file records can reach further than the table it counts.
       #
-      # This is therefore a lower bound. A symbol that is neither indexed by the
+      # Where the file records no such table, nothing records how large its
+      # symbol table is. The loader never enumerates it: it looks a name up
+      # through a hash table and jumps straight to an index, so where the table
+      # ends is none of its business. Two things bound it instead, the hash
+      # table that indexes the names a file exports and the relocations that
+      # name a symbol by index, and the answer is how far the further of the two
+      # reaches.
+      #
+      # That answer is a lower bound. A symbol that is neither indexed by the
       # hash table nor named by a relocation is invisible to both, and is
       # missing from the count. {#symbol_at} is exact for any index.
       # @return [Integer] The number.
@@ -57,7 +57,7 @@ module ELFTools
       #   elf.dynamic.num_symbols
       #   #=> 9
       def num_symbols
-        @num_symbols ||= (hash_tables.map(&:num_symbols) + [count_from_relocations]).compact.max || 0
+        @num_symbols ||= counted_num_symbols || bounded_num_symbols
       end
 
       # Iterate all symbols.
@@ -122,12 +122,34 @@ module ELFTools
         end
       end
 
+      # How many symbols a table that counts them says there are.
+      # @return [Integer, nil] The number, +nil+ if the file records no such table.
+      def counted_num_symbols
+        hash_tables.find(&:records_num_symbols?)&.num_symbols
+      end
+
+      # How far what the file records reaches, for a file that counts its
+      # symbols nowhere. Reading the relocations is what costs, so it is only
+      # done for such a file.
+      # @return [Integer] The number, zero if nothing reaches a symbol.
+      def bounded_num_symbols
+        (hash_tables.map(&:num_symbols) + [count_from_relocations]).compact.max || 0
+      end
+
       # How far the relocations reach, i.e. the highest index they name plus one.
       # They only ever name the symbols something in the file refers to.
       # @return [Integer, nil] The number, +nil+ if none names a symbol.
       def count_from_relocations
         highest = relocations.map(&:symbol_index).max
         highest && highest + 1
+      end
+
+      # How many bytes an entry of the symbol table takes, which is what its
+      # structure takes, which is also what +DT_SYMENT+ records and what a file
+      # has no way of disagreeing with.
+      # @return [Integer] The number.
+      def sym_entsize
+        @sym_entsize ||= struct(Structs::ELF_sym[header.elf_class]).num_bytes
       end
 
       # Get the +DT_SYMTAB+'s +d_val+ offset related to file.

--- a/spec/dynamic_spec.rb
+++ b/spec/dynamic_spec.rb
@@ -142,6 +142,23 @@ describe ELFTools::Dynamic do
       expect(elf('libc.so.6').dynamic.num_symbols).to eq 2245
     end
 
+    it 'stops at the table that counts the symbols' do
+      # DT_HASH counts every symbol, so nothing else a file records reaches
+      # past it and reading every relocation to find that out would be work
+      # for nothing.
+      dynamic = elf('libc.so.6').dynamic
+      expect(dynamic.tag_by_type(:hash)).not_to be nil
+      expect(dynamic).not_to receive(:relocations)
+      expect(dynamic.num_symbols).to eq 2245
+    end
+
+    it 'reaches for the relocations only where nothing counts the symbols' do
+      dynamic = elf('ppc64.elf').dynamic
+      expect(dynamic.tag_by_type(:hash)).to be nil
+      expect(dynamic).to receive(:relocations).and_call_original
+      expect(dynamic.num_symbols).to eq 13
+    end
+
     it 'names the symbol a relocation points at' do
       dynamic = elf('amd64.elf').dynamic
       expect(dynamic.relocations.map { |rel| dynamic.symbol_at(rel.symbol_index).name }).to eq \


### PR DESCRIPTION
Reading the symbols the dynamic tags point at cost far more than the work it does: 0.44s for the 2245 symbols of a 1.9MB libc, against 0.005s to hand-parse the same table with one byteslice and an unpack.

num_symbols took the largest share. It reached for every bound at once and answered with the furthest, so a file was read relocation by relocation to bound a number DT_HASH states outright. A chain of that table belongs to every symbol, which is why nchain is the count itself and not a bound on it, and why nothing else a file records can reach past it. Where a file records the table it is answered with, and the relocations are left alone. A file recording no such table is counted as before, from how far the GNU hash table and the relocations reach.

symbol_at paid the rest. It asked a structure how many bytes an entry takes and threw the structure away, once per symbol, so every symbol cost two BinData records where it needs one. The size belongs to the table rather than to the entry, and is now measured once for it.

Together that is 0.44s to 0.19s. What is read is unchanged: the symbols of every file here compare byte for byte against master, value and name and index, over sysv, gnu, and both hash styles in 32 and 64 bit, big endian included, and against a parser written from the ABI alone.