### PR TITLE
Read a relocation without building a structure for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,27 @@ entries here are collected from those announcements and from the commit history.
 
 - `Structs::ELFStruct.unpack_fields`, what the fields of a structure record read
   straight from the bytes recording them, and `.num_bytes`, how many bytes a structure
-  of a kind takes. `Structs::Fields` is what a structure the file records at an offset
+  of a kind takes. Both read a field of whichever width the class of the file makes it
+  and a field recording a sign, and say so rather than answer for a structure of
+  anything else. `Structs::Fields` is what a structure the file records at an offset
   holds, and builds the structure itself for whatever asks for one, which is what
-  assigning to a field takes
-  ([#127](https://github.com/david942j/rbelftools/pull/127))
+  assigning to a field takes; `Structs::Fields.from` holds what a file states some other
+  way than by recording a structure of it
+  ([#127](https://github.com/david942j/rbelftools/pull/127),
+  [#129](https://github.com/david942j/rbelftools/pull/129))
 
 ### Changed
 
+- Reading a relocation unpacks what the file records straight from the bytes recording
+  it, as reading a symbol does, and the relocations a file packs into a bitmap are made
+  without a structure each as well. One is built only for a caller that asks a relocation
+  for its `header`. The 1179 relocations of a libc cost 8 objects each rather than 179
+  and are read around 24 times faster, the tables the file records entry by entry and the
+  bitmap alike. `Dynamic#num_symbols` reads every relocation where no hash table counts
+  the symbols, which most files leave to `DT_GNU_HASH`, so reading the symbols of such a
+  file is four times faster again: 0.28s for a libc's 3103 symbols in 2.1.0, 0.08s once
+  the symbols alone were unpacked, 0.02s now. What is read is unchanged, relocation for
+  relocation ([#129](https://github.com/david942j/rbelftools/pull/129))
 - Reading a symbol unpacks what the file records straight from the bytes recording it,
   instead of building a structure for every symbol of a table. Setting up the fields of a
   structure is most of what one costs, and only a caller that asks a symbol for its

--- a/lib/elftools/dynamic.rb
+++ b/lib/elftools/dynamic.rb
@@ -176,30 +176,12 @@ module ELFTools
       # An entry takes what its structure takes. DT_RELAENT and DT_RELENT
       # record the same number, which a file has no way of disagreeing with
       # and every file here agrees with.
-      entsize = struct(klass).num_bytes
+      elf_class = header.elf_class
+      entsize = klass.num_bytes(elf_class: elf_class, endian: endian)
       Array.new(size.header.d_val.to_i / entsize) do |i|
-        Relocation.new(read_struct(klass, offset + (i * entsize)), stream, machine: @machine)
+        fields = Structs::Fields.new(klass, stream, offset + (i * entsize), elf_class: elf_class, endian: endian)
+        Relocation.new(fields, stream, machine: @machine)
       end
-    end
-
-    # A structure of the endianness and the class the file records it in.
-    # @param [Class] klass The structure class.
-    # @return [ELFTools::Structs::ELFStruct] The structure, before it is read.
-    def struct(klass)
-      struct = klass.new(endian:)
-      struct.elf_class = header.elf_class
-      struct
-    end
-
-    # Reads a structure the file records at a file offset.
-    # @param [Class] klass The structure class.
-    # @param [Integer] offset The file offset.
-    # @return [ELFTools::Structs::ELFStruct] The structure.
-    def read_struct(klass, offset)
-      struct = struct(klass)
-      struct.offset = offset
-      stream.pos = offset
-      struct.read(stream)
     end
 
     # The file offset the address a tag records points at.

--- a/lib/elftools/dynamic/symbols.rb
+++ b/lib/elftools/dynamic/symbols.rb
@@ -154,7 +154,7 @@ module ELFTools
       # has no way of disagreeing with.
       # @return [Integer] The number.
       def sym_entsize
-        @sym_entsize ||= Structs::ELF_sym[header.elf_class].num_bytes(endian)
+        @sym_entsize ||= Structs::ELF_sym[header.elf_class].num_bytes(elf_class: header.elf_class, endian: endian)
       end
 
       # What reads the table these symbols are named in, kept so that reading

--- a/lib/elftools/relative_relocations.rb
+++ b/lib/elftools/relative_relocations.rb
@@ -39,10 +39,9 @@ module ELFTools
     def to_a
       type = Constants::R.relative(@machine)
       addresses.map do |address, from|
-        rel = Structs::ELF_Rel.new(endian: @endian, offset: from)
-        rel.elf_class = @elf_class
-        rel.r_offset = address
-        relocation = Relocation.new(rel, @stream, machine: @machine)
+        fields = Structs::Fields.from(Structs::ELF_Rel, { r_offset: address, r_info: 0 },
+                                      elf_class: @elf_class, endian: @endian, offset: from)
+        relocation = Relocation.new(fields, @stream, machine: @machine)
         # Through the relocation, so that the type is laid out in +r_info+ the
         # way the machine lays it out.
         relocation.type = type if type

--- a/lib/elftools/relocation.rb
+++ b/lib/elftools/relocation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'elftools/constants'
+require 'elftools/structs'
 require 'elftools/util'
 
 module ELFTools
@@ -8,20 +9,31 @@ module ELFTools
   #
   # Can be either a REL or RELA relocation.
   class Relocation
-    attr_reader :header # @return [ELFTools::Structs::ELF_Rel, ELFTools::Structs::ELF_Rela] Rel(a) header.
     attr_reader :stream # @return [#pos=, #read] Streaming object.
 
     # Instantiate a {Relocation} object.
-    # @param [ELFTools::Structs::ELF_Rel, ELFTools::Structs::ELF_Rela] header
-    #   The relocation header.
+    # @param [ELFTools::Structs::ELF_Rel, ELFTools::Structs::ELF_Rela, ELFTools::Structs::Fields] header
+    #   The relocation header, or what the file records in one.
+    #   {ELFTools::Structs::Fields} answers what the relocation records until
+    #   something asks for {#header} itself, which builds the structure then.
     # @param [#pos=, #read] stream The streaming object.
     # @param [Integer] machine
     #   The machine of the ELF file, which decides what {#type} means and how
     #   {#header} records it.
     def initialize(header, stream, machine: nil)
-      @header = header
+      @fields = header.is_a?(Structs::Fields) ? header : Structs::Fields.of(header)
       @stream = stream
       @machine = machine
+    end
+
+    # The structure the file records this relocation in.
+    #
+    # One is built here for a relocation read without it, which is what
+    # assigning to a field of one needs and what {ELFTools::ELFFile#patches}
+    # reports the changes of.
+    # @return [ELFTools::Structs::ELF_Rel, ELFTools::Structs::ELF_Rela] The structure.
+    def header
+      @fields.struct
     end
 
     # Which symbol this relocation is against, as an index into the symbol
@@ -44,7 +56,7 @@ module ELFTools
     # @example
     #   relocation.symbol_index = 3
     def symbol_index=(index)
-      header.r_info = info_of(Util.fits!(index, index_bits, 'Symbol index'), type)
+      @fields[:r_info] = info_of(Util.fits!(index, index_bits, 'Symbol index'), type)
     end
 
     # Sets what this relocation does.
@@ -53,7 +65,7 @@ module ELFTools
     # @example
     #   relocation.type = ELFTools::Constants::R::X86_64::R_X86_64_JUMP_SLOT
     def type=(type)
-      header.r_info = info_of(symbol_index, Util.fits!(type, type_bits, 'Relocation type'))
+      @fields[:r_info] = info_of(symbol_index, Util.fits!(type, type_bits, 'Relocation type'))
     end
 
     # The name of {#type}.
@@ -83,8 +95,8 @@ module ELFTools
     # ABI keeps for itself as they were.
     # @return [Integer] The +r_info+.
     def mips64_info_of(index, type)
-      info = header.r_info.to_i
-      return (index << 32) | (info & 0xffff_ff00) | type if header.class.self_endian == :big
+      info = @fields[:r_info]
+      return (index << 32) | (info & 0xffff_ff00) | type if @fields.endian == :big
 
       (info & 0x00ff_ffff_0000_0000) | (type << 56) | index
     end
@@ -92,7 +104,7 @@ module ELFTools
     # How many bits record a symbol index.
     # @return [Integer] The number.
     def index_bits
-      mips64? ? 32 : (header.elf_class - mask_bit)
+      mips64? ? 32 : (@fields.elf_class - mask_bit)
     end
 
     # How many bits record a relocation type.
@@ -108,14 +120,15 @@ module ELFTools
     def sym_and_type
       return mips64_sym_and_type if mips64?
 
-      [header.r_info >> mask_bit, header.r_info & ((1 << mask_bit) - 1)]
+      info = @fields[:r_info]
+      [info >> mask_bit, info & ((1 << mask_bit) - 1)]
     end
 
     # Whether the file records relocations the way the 64-bit MIPS ABI does,
     # which is the one layout that departs from halving +r_info+.
     # @return [Boolean] The answer.
     def mips64?
-      @machine == Constants::EM_MIPS && header.elf_class == 64
+      @machine == Constants::EM_MIPS && @fields.elf_class == 64
     end
 
     # Reads +r_info+ as the 64-bit MIPS ABI records it, i.e. a symbol index of
@@ -131,14 +144,14 @@ module ELFTools
     #   0x0718050000000008 #=> [8, 7]
     # @return [Array(Integer, Integer)] The symbol index and the type.
     def mips64_sym_and_type
-      info = header.r_info.to_i
-      return [info >> 32, info & 0xff] if header.class.self_endian == :big
+      info = @fields[:r_info]
+      return [info >> 32, info & 0xff] if @fields.endian == :big
 
       [info & 0xffff_ffff, info >> 56]
     end
 
     def mask_bit
-      header.elf_class == 32 ? 8 : 32
+      @fields.elf_class == 32 ? 8 : 32
     end
   end
 end

--- a/lib/elftools/sections/relocation_section.rb
+++ b/lib/elftools/sections/relocation_section.rb
@@ -78,12 +78,23 @@ module ELFTools
       private
 
       def create_relocation(n)
-        stream.pos = header.sh_offset + n * header.sh_entsize
         klass = rela? ? Structs::ELF_Rela : Structs::ELF_Rel
-        rel = klass.new(endian: header.class.self_endian, offset: stream.pos)
-        rel.elf_class = header.elf_class
-        rel.read(stream)
-        Relocation.new(rel, stream, machine: @machine)
+        fields = Structs::Fields.new(klass, stream, table_offset + (n * entsize),
+                                     elf_class: header.elf_class, endian: header.class.self_endian)
+        Relocation.new(fields, stream, machine: @machine)
+      end
+
+      # Where this table starts in the file, asked of the header once rather
+      # than once for every relocation read.
+      # @return [Integer] The file offset.
+      def table_offset
+        @table_offset ||= header.sh_offset.to_i
+      end
+
+      # How many bytes this table spaces its entries by.
+      # @return [Integer] The number.
+      def entsize
+        @entsize ||= header.sh_entsize.to_i
       end
     end
   end

--- a/lib/elftools/sections/symbol.rb
+++ b/lib/elftools/sections/symbol.rb
@@ -26,7 +26,7 @@ module ELFTools
       #   Call this to get the version this symbol binds to, which only the
       #   symbols a file is loaded by have.
       def initialize(header, stream, symstr: nil, machine: nil, version: nil)
-        @header = header
+        @fields = header.is_a?(Structs::Fields) ? header : Structs::Fields.of(header)
         @stream = stream
         @symstr = symstr
         @machine = machine
@@ -40,14 +40,13 @@ module ELFTools
       # reports the changes of.
       # @return [ELFTools::Structs::ELF32_sym, ELFTools::Structs::ELF64_sym] The structure.
       def header
-        @header = @header.to_struct if @header.is_a?(Structs::Fields)
-        @header
+        @fields.struct
       end
 
       # Return the symbol name.
       # @return [String] The name.
       def name
-        @name ||= @symstr.call.name_at(field(:st_name))
+        @name ||= @symstr.call.name_at(@fields[:st_name])
       end
 
       # The version this symbol binds to.
@@ -83,7 +82,7 @@ module ELFTools
       #   elf.section_by_name('.symtab').symbol_by_name('main').value
       #   #=> 4196061 # 0x4006dd
       def value
-        field(:st_value)
+        @fields[:st_value]
       end
 
       # How many bytes what this symbol names takes.
@@ -92,7 +91,7 @@ module ELFTools
       #   elf.section_by_name('.symtab').symbol_by_name('main').size
       #   #=> 142
       def size
-        field(:st_size)
+        @fields[:st_size]
       end
 
       # What kind of entity this symbol refers to.
@@ -103,7 +102,7 @@ module ELFTools
       #   symbol.type == ELFTools::Constants::STT_FUNC
       #   #=> true
       def type
-        field(:st_info) & 0xf
+        @fields[:st_info] & 0xf
       end
 
       # Sets what kind of entity this symbol refers to.
@@ -135,7 +134,7 @@ module ELFTools
       #   symbol.bind == ELFTools::Constants::STB_GLOBAL
       #   #=> true
       def bind
-        field(:st_info) >> 4
+        @fields[:st_info] >> 4
       end
 
       # Sets how this symbol is linked against others with the same name.
@@ -165,7 +164,7 @@ module ELFTools
       #   symbol.visibility == ELFTools::Constants::STV_HIDDEN
       #   #=> true
       def visibility
-        field(:st_other) & 0x3
+        @fields[:st_other] & 0x3
       end
 
       # Sets how this symbol is accessed once it becomes part of an executable
@@ -190,19 +189,6 @@ module ELFTools
         Constants::STV.mapping(@machine, visibility)
       end
 
-      # What the file records in one of this symbol's fields.
-      #
-      # A structure answers wherever there is one, so that a field assigned to
-      # reads back as it was assigned.
-      # @param [Symbol] name The name of the field.
-      # @return [Integer] What it records.
-      def field(name)
-        return @header[name] if @header.is_a?(Structs::Fields)
-
-        header[name].to_i
-      end
-      private :field
-
       # The version this symbol binds to, whatever is asked of it.
       # @return [ELFTools::Dynamic::Versions::Version, nil] The version.
       def binding_version
@@ -221,7 +207,7 @@ module ELFTools
       #   symbol.section_index == ELFTools::Constants::SHN_UNDEF
       #   #=> true # the symbol is undefined and to be resolved at runtime
       def section_index
-        field(:st_shndx)
+        @fields[:st_shndx]
       end
     end
   end

--- a/lib/elftools/structs.rb
+++ b/lib/elftools/structs.rb
@@ -17,11 +17,22 @@ module ELFTools
         { selection: :elf_class, choices: { 32 => :"#{t}32", 64 => :"#{t}64" }, copy_on_change: true }
       end
 
-      # How an unsigned integer of each width is packed, for +String#unpack+.
+      # How an integer of each width is packed, for +String#unpack+, whether it
+      # records a sign or not.
       UNPACK_TEMPLATES = {
-        little: { 1 => 'C', 2 => 'v', 4 => 'V', 8 => 'Q<' },
-        big: { 1 => 'C', 2 => 'n', 4 => 'N', 8 => 'Q>' }
+        little: {
+          false => { 1 => 'C', 2 => 'v', 4 => 'V', 8 => 'Q<' },
+          true => { 1 => 'c', 2 => 's<', 4 => 'l<', 8 => 'q<' }
+        },
+        big: {
+          false => { 1 => 'C', 2 => 'n', 4 => 'N', 8 => 'Q>' },
+          true => { 1 => 'c', 2 => 's>', 4 => 'l>', 8 => 'q>' }
+        }
       }.freeze
+
+      # Bytes of set bits to read a prototype from, longer than any structure
+      # here, so that reading one never runs short of them.
+      SET_BITS = ("\xff" * 256).b.freeze
 
       attr_accessor :elf_class # @return [Integer] 32 or 64.
       attr_accessor :offset # @return [Integer] The file offset of this header.
@@ -126,30 +137,34 @@ module ELFTools
         # is remembered of the bytes, so a caller that means to assign to a
         # field wants a structure instead.
         # @param [String] bytes The bytes a structure is recorded in.
+        # @param [Integer] elf_class 32 or 64, which decides how wide the fields recording an address are.
         # @param [:little, :big] endian The endianness the file records it in.
         # @return [Hash{Symbol => Integer}] Each field, and what it records.
-        # @raise [ELFTools::ELFError] If this is not a structure of unsigned integers.
+        # @raise [ELFTools::ELFError] If this is not a structure of integers.
         # @example
-        #   ELF64_sym.unpack_fields(bytes, :little)
+        #   ELF64_sym.unpack_fields(bytes, elf_class: 64, endian: :little)
         #   #=> { st_name: 1, st_info: 18, st_other: 0, st_shndx: 15, st_value: 4198864, st_size: 101 }
-        def unpack_fields(bytes, endian)
-          values = bytes.unpack(unpack_template(endian))
+        def unpack_fields(bytes, elf_class:, endian:)
+          values = bytes.unpack(unpack_template(elf_class, endian))
           fields = {}
           # Paired by hand rather than zipped, which would make an array for
           # every field of every structure read.
-          field_names(endian).each_with_index { |name, i| fields[name] = values[i] }
+          field_names(elf_class, endian).each_with_index { |name, i| fields[name] = values[i] }
           fields
         end
 
         # How many bytes a structure of this kind takes.
+        # @param [Integer] elf_class 32 or 64, which decides how wide the fields recording an address are.
         # @param [:little, :big] endian The endianness the file records it in.
         # @return [Integer] The number.
         # @example
-        #   ELF64_sym.num_bytes(:little)
+        #   ELF64_sym.num_bytes(elf_class: 64, endian: :little)
         #   #=> 24
-        def num_bytes(endian)
+        def num_bytes(elf_class:, endian:)
           @num_bytes ||= {}
-          @num_bytes[endian] ||= prototype(endian).num_bytes
+          # Nested rather than keyed by the pair, which would make an array of
+          # it for every structure read.
+          (@num_bytes[elf_class] ||= {})[endian] ||= prototype(elf_class, endian).num_bytes
         end
 
         # Packs an integer to string.
@@ -175,45 +190,56 @@ module ELFTools
 
         private
 
-        # A structure of this kind, to read the layout off.
+        # A structure of this kind with every bit of it set, which the layout is
+        # read off: how wide each field is, and whether it records a sign.
         #
-        # Every structure of a kind is laid out alike, so one is built for the
-        # kind rather than for each question asked about it.
+        # Every structure of a kind and a class is laid out alike, so one is
+        # built for the kind rather than for each question asked about it.
+        # @param [Integer] elf_class 32 or 64, which decides how wide the fields recording an address are.
         # @param [:little, :big] endian The endianness the file records it in.
         # @return [ELFTools::Structs::ELFStruct] The structure.
-        def prototype(endian)
+        def prototype(elf_class, endian)
           @prototypes ||= {}
-          @prototypes[endian] ||= new(endian: endian)
+          (@prototypes[elf_class] ||= {})[endian] ||= begin
+            struct = new(endian: endian)
+            struct.elf_class = elf_class
+            struct.read(SET_BITS)
+          end
         end
 
         # What the fields of this structure are named, in the order they are
         # recorded.
+        # @param [Integer] elf_class 32 or 64, which decides how wide the fields recording an address are.
         # @param [:little, :big] endian The endianness the file records it in.
         # @return [Array<Symbol>] The names.
-        def field_names(endian)
+        def field_names(elf_class, endian)
           @field_names ||= {}
-          @field_names[endian] ||= prototype(endian).field_names
+          (@field_names[elf_class] ||= {})[endian] ||= prototype(elf_class, endian).field_names
         end
 
         # How the fields of this structure are packed, as a template for
         # +String#unpack+.
+        # @param [Integer] elf_class 32 or 64, which decides how wide the fields recording an address are.
         # @param [:little, :big] endian The endianness the file records it in.
         # @return [String] The template.
-        def unpack_template(endian)
+        def unpack_template(elf_class, endian)
           @unpack_templates ||= {}
-          @unpack_templates[endian] ||=
-            prototype(endian).each_pair.map { |_, field| field_template(field, endian) }.join
+          (@unpack_templates[elf_class] ||= {})[endian] ||=
+            prototype(elf_class, endian).each_pair.map { |_, field| field_template(field, endian) }.join
         end
 
-        # How one field is packed.
-        # @param [BinData::Base] field The field.
+        # How one field is packed, which is its width and whether what it read
+        # from a field of set bits came back negative.
+        # @param [BinData::Base] field The field, read from bits that are all set.
         # @param [:little, :big] endian The endianness the file records it in.
         # @return [String] The template.
-        # @raise [ELFTools::ELFError] If the field is not an unsigned integer of 1, 2, 4, or 8 bytes.
+        # @raise [ELFTools::ELFError] If the field is not an integer of 1, 2, 4, or 8 bytes.
         def field_template(field, endian)
-          width = field.num_bytes if field.is_a?(BinData::BasePrimitive)
-          UNPACK_TEMPLATES.fetch(endian)[width] ||
-            raise(ELFError, format('%s is not a structure of unsigned integers', name))
+          width = field.num_bytes
+          template = UNPACK_TEMPLATES.fetch(endian)
+          raise ELFError, format('%s is not a structure of integers', name) unless template[false].key?(width)
+
+          template.fetch(field.to_i.negative?)[width]
         end
       end
     end
@@ -223,9 +249,37 @@ module ELFTools
     #
     # Reading a table of structures costs a structure for every entry of it
     # otherwise, and setting up the fields of one is most of what it costs.
-    # {#to_struct} builds one for whatever wants the structure itself, which
-    # is what assigning to a field takes.
+    # {#struct} builds one for whatever wants the structure itself, which
+    # is what assigning to a field takes, and what is assigned is answered
+    # with from then on.
     class Fields
+      attr_reader :elf_class # @return [Integer] 32 or 64.
+      attr_reader :endian # @return [:little, :big] The endianness the file records it in.
+
+      # What a structure already built holds, for a caller that has one.
+      # @param [ELFTools::Structs::ELFStruct] struct The structure.
+      # @return [ELFTools::Structs::Fields] The fields.
+      def self.of(struct)
+        allocate.tap { |fields| fields.send(:built_from, struct) }
+      end
+
+      # Fields nothing in the file records, for what a file states some other
+      # way than by recording a structure of it.
+      #
+      # There is nothing to read and nothing to patch, so a structure is only
+      # built if something asks for one, and is built from these.
+      # @param [Class] klass The structure class.
+      # @param [Hash{Symbol => Integer}] fields What each field is to record.
+      # @param [Integer] elf_class 32 or 64.
+      # @param [:little, :big] endian The endianness the file records it in.
+      # @param [Integer] offset Where in the file this came from.
+      # @return [ELFTools::Structs::Fields] The fields.
+      # @example
+      #   Fields.from(ELF_Rel, { r_offset: 0x1000 }, elf_class: 64, endian: :little, offset: 0x40)
+      def self.from(klass, fields, elf_class:, endian:, offset:)
+        allocate.tap { |made| made.send(:made_of, klass, fields, elf_class, endian, offset) }
+      end
+
       # @param [Class] klass The structure class.
       # @param [#pos=, #read] stream The streaming object.
       # @param [Integer] offset The file offset the structure is recorded at.
@@ -242,36 +296,101 @@ module ELFTools
       end
 
       # What one field of the structure records.
+      #
+      # The structure answers once there is one, so that a field assigned to
+      # reads back as it was assigned.
       # @param [Symbol] name The name of the field.
       # @return [Integer] The value.
       # @example
       #   fields[:st_value]
       #   #=> 4198864
       def [](name)
+        return @struct[name].to_i if @struct
+
         @fields[name]
       end
 
-      # The structure itself, read again from where the file records it.
+      # Assigns to one field.
+      #
+      # The structure takes the assignment wherever the file records one, so
+      # that {ELFTools::ELFFile#patches} reports it. Fields the file records
+      # no structure of take it themselves, there being nothing to patch.
+      # @param [Symbol] name The name of the field.
+      # @param [Integer] value What it is to record.
+      # @return [void]
+      def []=(name, value)
+        if @struct.nil? && @stream.nil?
+          @fields[name] = value
+        else
+          struct[name] = value
+        end
+      end
+
+      # The structure itself, read from where the file records it, or built
+      # from these fields where it records none.
+      #
+      # The same one however often it is asked for, so that assigning to a
+      # field of it is not forgotten.
       # @return [ELFTools::Structs::ELFStruct] The structure.
-      def to_struct
-        struct = @klass.new(endian: @endian, offset: @offset)
-        struct.elf_class = @elf_class
+      def struct
+        @struct ||= @stream.nil? ? build : read
+      end
+
+      private
+
+      # Takes a structure that is already built as what these fields hold.
+      # @param [ELFTools::Structs::ELFStruct] struct The structure.
+      # @return [void]
+      def built_from(struct)
+        @struct = struct
+        @elf_class = struct.elf_class
+        @endian = struct.class.self_endian
+      end
+
+      # Takes fields nothing in the file records a structure of.
+      # @return [void]
+      def made_of(klass, fields, elf_class, endian, offset)
+        @klass = klass
+        @fields = fields
+        @elf_class = elf_class
+        @endian = endian
+        @offset = offset
+      end
+
+      # The structure the file records, read from where it records it.
+      # @return [ELFTools::Structs::ELFStruct] The structure.
+      def read
+        struct = new_struct
         @stream.pos = @offset
         struct.read(@stream)
       end
 
-      private
+      # A structure holding what these fields hold, for fields the file
+      # records no structure of.
+      # @return [ELFTools::Structs::ELFStruct] The structure.
+      def build
+        new_struct.tap { |struct| @fields.each { |name, value| struct[name] = value } }
+      end
+
+      # A structure of this kind, of the class and the order of the file, and
+      # of where in it this came from.
+      # @return [ELFTools::Structs::ELFStruct] The structure.
+      def new_struct
+        struct = @klass.new(endian: @endian, offset: @offset)
+        struct.elf_class = @elf_class
+        struct
+      end
 
       # What the fields record, read from the bytes recording them.
       # @return [Hash{Symbol => Integer}] Each field, and what it records.
       # @raise [EOFError] If the file does not reach that far, as reading the structure itself does.
       def unpack
-        num_bytes = @klass.num_bytes(@endian)
+        num_bytes = @klass.num_bytes(elf_class: @elf_class, endian: @endian)
         @stream.pos = @offset
         bytes = @stream.read(num_bytes)
         raise EOFError, 'End of file reached' if bytes.nil? || bytes.bytesize < num_bytes
 
-        @klass.unpack_fields(bytes, @endian)
+        @klass.unpack_fields(bytes, elf_class: @elf_class, endian: @endian)
       end
     end
 

--- a/spec/relocation_spec.rb
+++ b/spec/relocation_spec.rb
@@ -52,6 +52,20 @@ describe ELFTools::Relocation do
     expect(little.header.r_info.to_i).to eq 0x0518_0500_0000_0009
   end
 
+  it 'takes a structure a caller has built itself' do
+    # What {Relocation.new} has always taken, kept working for whoever builds
+    # a relocation of their own rather than reading one out of a file.
+    struct = ELFTools::Structs::ELF_Rela.new(endian: :little)
+    struct.elf_class = 64
+    struct.r_info = (3 << 32) | 7
+    rel = ELFTools::Relocation.new(struct, nil, machine: ELFTools::Constants::EM_X86_64)
+    expect([rel.symbol_index, rel.type, rel.type_name]).to eq [3, 7, 'R_X86_64_JUMP_SLOT']
+    expect(rel.header).to equal struct
+    # Assigning reaches the very structure it was given.
+    rel.type = ELFTools::Constants::R::X86_64::R_X86_64_GLOB_DAT
+    expect(struct.r_info.to_i).to eq((3 << 32) | ELFTools::Constants::R::X86_64::R_X86_64_GLOB_DAT)
+  end
+
   it 'reports a value the bits recording it cannot hold' do
     # A 32-bit file leaves a type one byte and a symbol index the other three.
     rel = relocations('i386.elf').first

--- a/spec/structs_spec.rb
+++ b/spec/structs_spec.rb
@@ -58,34 +58,79 @@ describe ELFTools::Structs::ELFStruct do
   end
 
   describe '.unpack_fields' do
-    it 'reads what the structure reads, of either class and in either order' do
-      %w[amd64.elf i386.elf mips.o mips64.o].each do |name|
-        elf = ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', name)))
-        symtab = elf.section_by_name('.symtab')
-        klass = ELFTools::Structs::ELF_sym[elf.elf_class]
-        expect(symtab.num_symbols).to be_positive
-        symtab.num_symbols.times do |n|
-          elf.stream.pos = symtab.header.sh_offset + (n * symtab.header.sh_entsize)
-          bytes = elf.stream.read(klass.num_bytes(elf.endian))
-          struct = klass.new(endian: elf.endian)
-          struct.read(StringIO.new(bytes))
-          expect(klass.unpack_fields(bytes, elf.endian)).to eq struct.snapshot
-        end
+    # Which structure a table records, for the tables elftools reads entry by
+    # entry.
+    def entry_class(section, elf)
+      case section.header.sh_type.to_i
+      when ELFTools::Constants::SHT_SYMTAB, ELFTools::Constants::SHT_DYNSYM
+        ELFTools::Structs::ELF_sym[elf.elf_class]
+      when ELFTools::Constants::SHT_REL then ELFTools::Structs::ELF_Rel
+      when ELFTools::Constants::SHT_RELA then ELFTools::Structs::ELF_Rela
+      when ELFTools::Constants::SHT_DYNAMIC then ELFTools::Structs::ELF_Dyn
       end
     end
 
-    it 'reports a structure that is not one of unsigned integers' do
-      # e_ident is a structure of its own and the fields recording addresses
-      # are of whichever width the class of the file makes them.
-      expect { ELFTools::Structs::ELF_Ehdr.unpack_fields('x' * 64, :little) }
-        .to raise_error(ELFTools::ELFError, 'ELFTools::Structs::ELF_Ehdr is not a structure of unsigned integers')
+    # What the structure reads from the same bytes, which is what the file
+    # says they hold.
+    def read_with_bindata(klass, bytes, elf)
+      struct = klass.new(endian: elf.endian)
+      struct.elf_class = elf.elf_class
+      struct.read(StringIO.new(bytes))
+      struct.snapshot
+    end
+
+    it 'reads what the structure reads, of either class and in either order' do
+      read = 0
+      %w[amd64.elf i386.elf arm.elf mips.o mips64.o ppc64.elf riscv64.elf aarch64.elf libc.so.6].each do |name|
+        elf = ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', name)))
+        elf.sections.each do |section|
+          klass = entry_class(section, elf)
+          next if klass.nil?
+
+          entsize = section.header.sh_entsize.to_i
+          (section.header.sh_size.to_i / entsize).times do |n|
+            elf.stream.pos = section.header.sh_offset.to_i + (n * entsize)
+            bytes = elf.stream.read(klass.num_bytes(elf_class: elf.elf_class, endian: elf.endian))
+            expect(klass.unpack_fields(bytes, elf_class: elf.elf_class, endian: elf.endian))
+              .to eq read_with_bindata(klass, bytes, elf)
+            read += 1
+          end
+        end
+      end
+      # Symbols, relocations of both kinds, and tags, of both classes and both
+      # byte orders.
+      expect(read).to be > 1000
+    end
+
+    it 'reads a field recording a sign as one, and one recording none as none' do
+      # An addend is the one field of a relocation that records a sign, so
+      # every bit of it set is -1 where the same bits of an offset are not.
+      rela = ELFTools::Structs::ELF_Rela
+      expect(rela.unpack_fields("\xff" * 24, elf_class: 64, endian: :little))
+        .to eq({ r_offset: 0xffff_ffff_ffff_ffff, r_info: 0xffff_ffff_ffff_ffff, r_addend: -1 })
+      expect(rela.unpack_fields([8, 5, -16].pack('Q<Q<q<'), elf_class: 64, endian: :little))
+        .to eq({ r_offset: 8, r_info: 5, r_addend: -16 })
+      expect(rela.unpack_fields([8, 5, -16].pack('Q>Q>q>'), elf_class: 64, endian: :big))
+        .to eq({ r_offset: 8, r_info: 5, r_addend: -16 })
+      # A tag records one as well, of a width the class of the file decides.
+      expect(ELFTools::Structs::ELF_Dyn.unpack_fields([-3, 9].pack('l<L<'), elf_class: 32, endian: :little))
+        .to eq({ d_tag: -3, d_val: 9 })
+    end
+
+    it 'reports a structure that is not one of integers' do
+      # e_ident is a structure of its own, which nothing here unpacks.
+      expect { ELFTools::Structs::ELF_Ehdr.unpack_fields('x' * 64, elf_class: 64, endian: :little) }
+        .to raise_error(ELFTools::ELFError, 'ELFTools::Structs::ELF_Ehdr is not a structure of integers')
     end
   end
 
   describe '.num_bytes' do
     it 'is how many bytes a structure of the kind takes' do
-      expect(ELFTools::Structs::ELF32_sym.num_bytes(:little)).to be 16
-      expect(ELFTools::Structs::ELF64_sym.num_bytes(:big)).to be 24
+      expect(ELFTools::Structs::ELF32_sym.num_bytes(elf_class: 32, endian: :little)).to be 16
+      expect(ELFTools::Structs::ELF64_sym.num_bytes(elf_class: 64, endian: :big)).to be 24
+      # The fields recording an address are as wide as the class of the file.
+      expect(ELFTools::Structs::ELF_Rela.num_bytes(elf_class: 32, endian: :little)).to be 12
+      expect(ELFTools::Structs::ELF_Rela.num_bytes(elf_class: 64, endian: :little)).to be 24
     end
   end
 

--- a/spec/symbol_spec.rb
+++ b/spec/symbol_spec.rb
@@ -159,6 +159,21 @@ describe ELFTools::Sections::Symbol do
     end
   end
 
+  it 'takes a structure a caller has built itself' do
+    # What {Symbol.new} has always taken, kept working for whoever builds a
+    # symbol of their own rather than reading one out of a file.
+    struct = ELFTools::Structs::ELF64_sym.new(endian: :little)
+    struct.elf_class = 64
+    struct.st_value = 0x1234
+    struct.st_info = 0x12
+    sym = ELFTools::Sections::Symbol.new(struct, nil, machine: ELFTools::Constants::EM_X86_64)
+    expect([sym.value, sym.type_name, sym.bind_name]).to eq [0x1234, 'STT_FUNC', 'STB_GLOBAL']
+    expect(sym.header).to equal struct
+    # Assigning reaches the very structure it was given.
+    sym.type = ELFTools::Constants::STT_OBJECT
+    expect(struct.st_info.to_i).to be 0x11
+  end
+
   it 'size' do
     expect(@symtab.symbol_by_name('main').size).to be 142
     # A symbol the file records no size for, of which every file has some.


### PR DESCRIPTION
Relocations were left as symbols were before #127: a bindata structure for every entry, 179 objects and 0.065s for the 1179 a libc records, and it is not only paid by a caller that asks for them. num_symbols reads every relocation in the file where no hash table counts the symbols, which is what a file recording only DT_GNU_HASH leaves it to, so the cold reading of a libc's symbols was still 89 objects a symbol after #127, of which 79 were relocations.

Structs::Fields now reads them, as it reads symbols. Two things had to grow for it. The fields of a relocation are as wide as the class of the file makes them, declared as bindata choices, so the layout is read off a prototype of the class in hand rather than of the kind alone; and r_addend records a sign, so the prototype is read from bits that are all set and a field that comes back as -1 is unpacked as signed. A structure of anything else, e_ident for one, still says so rather than being read wrongly.

The relocations a file packs into a bitmap are 91% of what this machine's libc records, and they are not read from a table at all: RelativeRelocations makes each one up. Structs::Fields.from holds fields like those, with nothing to read and nothing to patch, and builds a structure only for a caller that asks. Assigning to a field of one reaches the fields themselves; assigning to a field the file does record goes on reaching the structure, so what ELFFile#patches reports is unchanged.

  libc                     master (#128)      this
  dynamic relocations      179.0 each         7.7 each     0.065s -> 0.003s
  section .rela.dyn        231.0 each         8.0 each     0.112s -> 0.004s
  symbols, cold            89 per symbol      18           0.084s -> 0.020s

Against 2.1.0 the reported repro reads that libc's 3103 symbols in 0.020s and 18 objects a symbol, from 0.280s and 283.

4547 lines of every field of every relocation of 21 files, and the 15049 of every symbol, are identical to what master reads, patching included, the 64-bit MIPS layout and the packed relocations among them.

Dynamic#struct and #read_struct are gone, nothing calling them any more.