### PR TITLE
Read a tag without building a structure for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ entries here are collected from those announcements and from the commit history.
 
 ### Added
 
+- `Dynamic::Tag#type`, what kind of tag it is, which took reaching into its header
+  ([#131](https://github.com/david942j/rbelftools/pull/131))
 - `Structs::ELFStruct.unpack_fields` and `.num_bytes`, and `Structs::Fields`, which reads a
   structure's fields from its bytes and builds the structure only when something asks
   ([#127](https://github.com/david942j/rbelftools/pull/127),
@@ -21,6 +23,9 @@ entries here are collected from those announcements and from the commit history.
 
 ### Changed
 
+- Reading a dynamic tag unpacks its bytes rather than building a structure, so looking one
+  up reads no structure at all: 10 objects a tag rather than 208
+  ([#131](https://github.com/david942j/rbelftools/pull/131))
 - Reading a relocation unpacks its bytes rather than building a structure, packed ones
   included: 8 objects an entry rather than 179, and `Dynamic#num_symbols` four times faster
   where it reads them all ([#129](https://github.com/david942j/rbelftools/pull/129))

--- a/lib/elftools/dynamic.rb
+++ b/lib/elftools/dynamic.rb
@@ -38,7 +38,7 @@ module ELFTools
       0.step do |i|
         tag = tag_at(i).tap(&block)
         arr << tag
-        break if tag.header.d_tag == ELFTools::Constants::DT_NULL
+        break if tag.type == ELFTools::Constants::DT_NULL
       end
       arr
     end
@@ -79,7 +79,7 @@ module ELFTools
     #   #=> #<ELFTools::Dynamic::Tag:0x0055d3d2d91b28 @header={:d_tag=>3, :d_val=>6295552}>
     def tag_by_type(type)
       type = Util.to_constant(Constants::DT, type)
-      each_tag.find { |tag| tag.header.d_tag == type }
+      each_tag.find { |tag| tag.type == type }
     end
 
     # Get tags of specific type.
@@ -91,7 +91,7 @@ module ELFTools
     # @see #tag_by_type
     def tags_by_type(type)
       type = Util.to_constant(Constants::DT, type)
-      each_tag.select { |tag| tag.header.d_tag == type }
+      each_tag.select { |tag| tag.type == type }
     end
 
     # Get the +n+-th tag.
@@ -112,11 +112,10 @@ module ELFTools
       @tag_at_map ||= {}
       return @tag_at_map[n] if @tag_at_map[n]
 
-      dyn = Structs::ELF_Dyn.new(endian:)
-      dyn.elf_class = header.elf_class
-      stream.pos = tag_start + n * dyn.num_bytes
-      dyn.offset = stream.pos
-      @tag_at_map[n] = Tag.new(dyn.read(stream), stream, string_table)
+      elf_class = header.elf_class
+      offset = tag_start + (n * Structs::ELF_Dyn.num_bytes(elf_class: elf_class, endian: endian))
+      fields = Structs::Fields.new(Structs::ELF_Dyn, stream, offset, elf_class: elf_class, endian: endian)
+      @tag_at_map[n] = Tag.new(fields, stream, string_table)
     end
 
     # The relocations the tags point at.
@@ -192,7 +191,7 @@ module ELFTools
     def offset_of(tag)
       vma = tag.header.d_val.to_i
       @offset_from_vma.call(vma) ||
-        raise(ELFError, format('Invalid %s address 0x%x', Constants::DT.mapping(@machine, tag.header.d_tag.to_i), vma))
+        raise(ELFError, format('Invalid %s address 0x%x', Constants::DT.mapping(@machine, tag.type), vma))
     end
 
     # The names the tags and the symbols point at.

--- a/lib/elftools/dynamic/tag.rb
+++ b/lib/elftools/dynamic/tag.rb
@@ -1,23 +1,45 @@
 # frozen_string_literal: true
 
 require 'elftools/constants'
+require 'elftools/structs'
 
 module ELFTools
   module Dynamic
     # A tag class.
     class Tag
-      attr_reader :header # @return [ELFTools::Structs::ELF_Dyn] The dynamic tag header.
       attr_reader :stream # @return [#pos=, #read] Streaming object.
 
       # Instantiate a {ELFTools::Dynamic::Tag} object.
-      # @param [ELF_Dyn] header The dynamic tag header.
+      # @param [ELFTools::Structs::ELF_Dyn, ELFTools::Structs::Fields] header
+      #   The dynamic tag header, or what the file records in one.
+      #   {ELFTools::Structs::Fields} answers what the tag records until
+      #   something asks for {#header} itself, which builds the structure then.
       # @param [#pos=, #read] stream Streaming object.
       # @param [ELFTools::Dynamic::StringTable] strtab
       #   The string table the names of tags are recorded in.
       def initialize(header, stream, strtab)
-        @header = header
+        @fields = header.is_a?(Structs::Fields) ? header : Structs::Fields.of(header)
         @stream = stream
         @strtab = strtab
+      end
+
+      # The structure the file records this tag in.
+      #
+      # One is built here for a tag read without it, which is what assigning to
+      # a field of one needs and what {ELFTools::ELFFile#patches} reports the
+      # changes of.
+      # @return [ELFTools::Structs::ELF_Dyn] The structure.
+      def header
+        @fields.struct
+      end
+
+      # What kind of tag this is, which {ELFTools::Constants::DT} names.
+      # @return [Integer] The type.
+      # @example
+      #   dynamic.tag_by_type(:needed).type == ELFTools::Constants::DT_NEEDED
+      #   #=> true
+      def type
+        @fields[:d_tag]
       end
 
       # Some dynamic have name.
@@ -40,7 +62,7 @@ module ELFTools
       #   dynamic.tag_by_type(:needed).value
       #   #=> 'libc.so.6'
       def value
-        name || header.d_val.to_i
+        name || @fields[:d_val]
       end
 
       # Is this tag has a name?
@@ -48,7 +70,7 @@ module ELFTools
       # The criteria here is if this tag's type is in {TYPE_WITH_NAME}.
       # @return [Boolean] Is this tag has a name.
       def name?
-        TYPE_WITH_NAME.include?(header.d_tag)
+        TYPE_WITH_NAME.include?(type)
       end
 
       # Return the name of this tag.
@@ -59,7 +81,7 @@ module ELFTools
       def name
         return nil unless name?
 
-        @strtab.name_at(header.d_val.to_i)
+        @strtab.name_at(@fields[:d_val])
       end
     end
   end

--- a/spec/dynamic_spec.rb
+++ b/spec/dynamic_spec.rb
@@ -71,6 +71,21 @@ describe ELFTools::Dynamic do
       expect(@segment.tag_by_type(:init).value).to be 0x400510
       expect(@segment.tag_by_type(:needed).value).to eq 'libc.so.6'
     end
+
+    it 'names what kind of tag it is' do
+      expect(@segment.tag_by_type(:needed).type).to be ELFTools::Constants::DT_NEEDED
+      expect(@segment.tag_at(0).type).to be ELFTools::Constants::DT_NEEDED
+      expect(@segment.tags.last.type).to be ELFTools::Constants::DT_NULL
+    end
+
+    it 'reads what a tag records without building a structure for it' do
+      # A structure of its own for every tag costs over two hundred objects
+      # each, which looking a tag up used to be spent on.
+      dynamic = ELFTools::ELFFile.new(File.open(File.join(__dir__, 'files', 'libc.so.6'))).dynamic
+      before = GC.stat(:total_allocated_objects)
+      dynamic.tags_by_type(:needed)
+      expect(GC.stat(:total_allocated_objects) - before).to be < (50 * dynamic.tags.size)
+    end
   end
 
   describe 'relocations' do


### PR DESCRIPTION
Tags were the last of the three left building a bindata structure each, 208 objects a tag. A file records only some thirty of them, but every tag_by_type walks them until it finds the one it wants, and reading a file at all asks after DT_STRTAB, DT_SYMTAB and the relocation tables, so the tags were read over and over.

Structs::Fields reads them now, as it reads symbols and relocations, and Dynamic::Tag#type answers what kind of tag it is, which took reaching into the header. The lookups compare that rather than a field of a structure, so finding a tag builds none at all: 10 objects a tag and 18 times faster for a libc's 28.

577 lines of every tag of 21 files, what each is worth, what each names, and what the lookups answer, are identical to what master reads, and so is what patching one reports.