### PR TITLE
Report a change to a tag or to a symbol the tags point at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ entries here are collected from those announcements and from the commit history.
   ([#127](https://github.com/david942j/rbelftools/pull/127),
   [#129](https://github.com/david942j/rbelftools/pull/129))
 
+### Fixed
+
+- `ELFFile#patches` and `#save` dropped a change made to a dynamic tag or to a symbol read
+  through the tags, which are remembered in a hash rather than an array and so were never
+  reached ([#132](https://github.com/david942j/rbelftools/pull/132))
+
 ### Changed
 
 - Reading a dynamic tag unpacks its bytes rather than building a structure, so looking one

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -373,18 +373,35 @@ module ELFTools
 
     # bad idea..
     def loaded_headers
-      explore = lambda do |obj|
-        return obj if obj.is_a?(::ELFTools::Structs::ELFStruct)
-        return obj.map(&explore) if obj.is_a?(Array)
-        # A class is not one of the things a file records, and what a class
-        # holds leads round in circles.
-        return [] if obj.is_a?(Module)
+      # By identity, so that a graph that reaches the same thing by many paths,
+      # or leads round in circles, is walked once rather than over and over.
+      headers_in(self, {}.compare_by_identity).flatten
+    end
 
-        obj.instance_variables.map do |s|
-          explore.call(obj.instance_variable_get(s))
-        end
-      end
-      explore.call(self).flatten
+    # The structures reachable from an object, whatever holds them.
+    # @param [Object] obj The object.
+    # @param [Hash] seen What has been reached already.
+    # @return [Array] The structures, nested.
+    def headers_in(obj, seen)
+      # A class is not one of the things a file records.
+      return [] if seen[obj] || obj.is_a?(Module)
+
+      seen[obj] = true
+      return obj if obj.is_a?(::ELFTools::Structs::ELFStruct)
+
+      held_by(obj).map { |held| headers_in(held, seen) }
+    end
+
+    # What an object holds, which a walk of it goes on to.
+    # @param [Object] obj The object.
+    # @return [Enumerable] What it holds.
+    def held_by(obj)
+      return obj if obj.is_a?(Array)
+      # A hash is held by its values, which is where the tags and the symbols
+      # read through the tags are remembered.
+      return obj.each_value if obj.is_a?(Hash)
+
+      obj.instance_variables.map { |name| obj.instance_variable_get(name) }
     end
 
     def identify

--- a/spec/elf_file_spec.rb
+++ b/spec/elf_file_spec.rb
@@ -210,6 +210,25 @@ describe ELFTools::ELFFile do
       out.close!
     end
 
+    it 'reports what a tag and a symbol read through the tags were assigned' do
+      # Both are remembered in a hash rather than an array, which used to keep
+      # them out of the answer and out of what was written.
+      elf = described_class.new(File.open(@filepath))
+      tag = elf.dynamic.tag_by_type(:strtab)
+      tag.header.d_val = 0x4142
+      elf.dynamic.symbol_at(1).type = ELFTools::Constants::STT_OBJECT
+      expect(elf.patches.size).to be 2
+
+      out = Tempfile.new('elftools')
+      out.close
+      elf.save(out.path)
+      out.reopen(out.path, 'rb')
+      saved = described_class.new(out)
+      expect(saved.dynamic.tag_by_type(:strtab).header.d_val.to_i).to be 0x4142
+      expect(saved.dynamic.symbol_at(1).type).to be ELFTools::Constants::STT_OBJECT
+      out.close!
+    end
+
     it 'patch header' do
       out = Tempfile.new('elftools')
       out.close


### PR DESCRIPTION
ELFFile#patches walks what a file has read looking for structures that have been assigned to. It followed arrays and instance variables but not hashes, and a dynamic tag and a symbol read through the tags are remembered in one, so assigning to either was reported as nothing and save wrote the file out unchanged. A section's symbols were reported, being held in a LazyArray, so which of two identical-looking assignments took effect depended on which view the symbol had been read through.

Following hashes alone overran the stack. A bindata Choice holds its parameters in a BinData::SanitizedParameters, which is a Hash, and from there the walk wanders into bindata's sanitized prototypes, which lead back to their classes and round again. What has been reached is now remembered by identity, so a graph that leads round in circles, or reaches the same thing by many paths, is walked once. Collecting the patches of a libc that has been read through is 0.045s rather than 0.070s for it, and half the objects.

Reading is untouched, and a file that has been read and saved is still byte-for-byte what it was.