### PR TITLE
Count what a file too large for the ELF header states elsewhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,21 @@ entries here are collected from those announcements and from the commit history.
 
 ### Added
 
+- `Constants::PN_XNUM`, the escape value the ELF header records where it cannot hold a
+  count of the program headers ([#133](https://github.com/david942j/rbelftools/pull/133))
 - `Dynamic::Tag#type`, what kind of tag it is, which took reaching into its header
   ([#131](https://github.com/david942j/rbelftools/pull/131))
 - `Structs::ELFStruct.unpack_fields` and `.num_bytes`, and `Structs::Fields`, which reads a
   structure's fields from its bytes and builds the structure only when something asks
   ([#127](https://github.com/david942j/rbelftools/pull/127),
   [#129](https://github.com/david942j/rbelftools/pull/129))
+
+### Fixed
+
+- A file with more sections or segments than the ELF header can count reported none of
+  them. Such a file records a zero, or `SHN_XINDEX`, and states the number in its first
+  section header, which `ELFFile#num_sections`, `#num_segments`, and `#section_name_table`
+  now read ([#133](https://github.com/david942j/rbelftools/pull/133))
 
 ### Changed
 

--- a/lib/elftools/constants.rb
+++ b/lib/elftools/constants.rb
@@ -466,6 +466,15 @@ module ELFTools
     end
     include SHN
 
+    # The escape value the ELF header records where it cannot hold a count of
+    # the program headers, which is then recorded in the first section header.
+    module PN
+      extend Naming
+
+      PN_XNUM = 0xffff # the number of program headers is too large for the header to hold
+    end
+    include PN
+
     # Section flag mask types, records in +sh_flag+.
     module SHF
       SHF_WRITE = (1 << 0) # Writable

--- a/lib/elftools/elf_file.rb
+++ b/lib/elftools/elf_file.rb
@@ -105,12 +105,19 @@ module ELFTools
     #========= method about sections
 
     # Number of sections in this file.
+    #
+    # A file with more sections than the ELF header can count records a zero
+    # there and states the number in the first section header instead, which a
+    # file with no section headers at all records as well.
     # @return [Integer] The desired number.
     # @example
     #   elf.num_sections
     #   #=> 29
     def num_sections
-      header.e_shnum
+      count = header.e_shnum.to_i
+      return count unless count.zero? && !header.e_shoff.to_i.zero?
+
+      first_section_header.sh_size.to_i
     end
 
     # Acquire the section named as +name+.
@@ -197,15 +204,25 @@ module ELFTools
     #   elf.section_name_table.name
     #   #=> '.shstrtab'
     def section_name_table
-      section_at(header.e_shstrndx)
+      index = header.e_shstrndx.to_i
+      # An index too large for the ELF header is stated in the first section
+      # header instead.
+      index = first_section_header.sh_link.to_i if index == Constants::SHN_XINDEX
+      section_at(index)
     end
 
     #========= method about segments
 
     # Number of segments in this file.
+    #
+    # A file with more segments than the ELF header can count states the number
+    # in the first section header instead, as it does for the sections.
     # @return [Integer] The desited number.
     def num_segments
-      header.e_phnum
+      count = header.e_phnum.to_i
+      return count unless count == Constants::PN_XNUM
+
+      first_section_header.sh_info.to_i
     end
 
     # Iterate all segments.
@@ -405,6 +422,18 @@ module ELFTools
         2 => :big
       }[ei_data]
       raise ELFDataError, format('Invalid EI_DATA "\x%02x"', ei_data) if endian.nil?
+    end
+
+    # The first section header, which is where a file too large for the counts
+    # the ELF header records states them.
+    # @return [ELFTools::Structs::ELF_Shdr] The header.
+    def first_section_header
+      @first_section_header ||= begin
+        stream.pos = header.e_shoff.to_i
+        shdr = Structs::ELF_Shdr.new(endian:, offset: stream.pos)
+        shdr.elf_class = elf_class
+        shdr.read(stream)
+      end
     end
 
     def create_section(n)

--- a/spec/elf_file_spec.rb
+++ b/spec/elf_file_spec.rb
@@ -200,6 +200,48 @@ describe ELFTools::ELFFile do
     end
   end
 
+  describe 'a file too large for the counts the ELF header records' do
+    # A real file with 65280 sections is enormous, so this is amd64.elf with
+    # its counts moved to where such a file states them.
+    def extended
+      data = File.binread(@filepath)
+      elf = described_class.new(StringIO.new(data))
+      counts = [elf.num_sections, elf.header.e_shstrndx.to_i, elf.num_segments]
+      zero = elf.section_at(0).header
+      zero.sh_size, zero.sh_link, zero.sh_info = counts
+      elf.header.e_shnum = 0
+      elf.header.e_shstrndx = ELFTools::Constants::SHN_XINDEX
+      elf.header.e_phnum = ELFTools::Constants::PN_XNUM
+      data[0, elf.header.num_bytes] = elf.header.to_binary_s
+      data[elf.header.e_shoff.to_i, zero.num_bytes] = zero.to_binary_s
+      [described_class.new(StringIO.new(data)), counts]
+    end
+
+    it 'counts what the first section header states' do
+      elf, counts = extended
+      expect([elf.num_sections, elf.num_segments]).to eq [counts[0], counts[2]]
+      expect(elf.sections.size).to be counts[0]
+      expect(elf.segments.size).to be counts[2]
+    end
+
+    it 'names its sections through the index the first section header states' do
+      elf, = extended
+      expect(elf.section_name_table.name).to eq '.shstrtab'
+      expect(elf.section_by_name('.text')).not_to be nil
+      expect(elf.sections.map(&:name)).to include '.dynsym', '.shstrtab'
+    end
+
+    it 'counts no sections where a file records no section headers' do
+      # The same zero, of a file that has none rather than too many.
+      data = File.binread(@filepath)
+      header = described_class.new(StringIO.new(data)).header
+      header.e_shoff = 0
+      header.e_shnum = 0
+      data[0, header.num_bytes] = header.to_binary_s
+      expect(described_class.new(StringIO.new(data)).num_sections).to be 0
+    end
+  end
+
   describe 'patches' do
     it 'dup' do
       out = Tempfile.new('elftools')


### PR DESCRIPTION
e_shnum, e_phnum and e_shstrndx are each sixteen bits, which a file with 65280 sections or more overruns. Such a file records a zero for the sections, PN_XNUM for the segments, and SHN_XINDEX for the index of the section names, and states each of the three in the first section header, in sh_size, sh_info and sh_link. Both constants were already defined here and nothing consulted them, so num_sections answered zero and the file read as having nothing in it at all.

A zero for the sections means two things, so the section headers are only consulted for a file that has some: one whose e_shoff is zero has none, and still counts zero.

A file with that many sections is far too large to keep as a fixture, so the specs move amd64.elf's own counts to where such a file states them and read it back. Every other fixture counts and names exactly what it did.